### PR TITLE
ADD handle validation set for the first iteration

### DIFF
--- a/arcann_training/training/prepare.py
+++ b/arcann_training/training/prepare.py
@@ -314,9 +314,10 @@ def main(
     del data_dir
 
     # TODO Implement validation dataset
-    del validation_datasets
+    # del validation_datasets
 
     # Training sets list construction
+    #TODO construct the same list for the validation dataset
     dp_train_input_datasets = []
     training_datasets = []
 
@@ -463,20 +464,36 @@ def main(
     else:
         del extra_datasets
 
+    # and the validation sets now
+    dp_validate_input_datasets = []
+    validation_count = 0
+    for validation_dataset in validation_datasets:
+        dp_validate_input_datasets.append(
+            f"{(Path(data_path.parts[-1]) / validation_dataset / '_')}"[:-1]
+        )
+        validation_count += np.load(
+            data_path / validation_dataset / "set.000" / "box.npy"
+        ).shape[0]
+        del validation_dataset
+
     # Total
     trained_count = initial_count + added_auto_count + added_adhoc_count + extra_count
     arcann_logger.debug(
         f"trained_count: {trained_count} = {initial_count} + {added_auto_count} + {added_adhoc_count} + {extra_count}"
     )
     arcann_logger.debug(f"dp_train_input_datasets: {dp_train_input_datasets}")
+    arcann_logger.debug(f"validation_count: {validation_count}")
+    arcann_logger.debug(f"dp_validate_input_datasets: {dp_validate_input_datasets}")
 
     # Update the inputs with the sets
     dp_train_input["training"]["training_data"]["systems"] = dp_train_input_datasets
+    dp_train_input["training"]["validation_data"]["systems"] = dp_validate_input_datasets
 
     # Update the training JSON
     training_json = {
         **training_json,
         "training_datasets": training_datasets,
+        "validation_datasets": validation_datasets,
         "trained_count": trained_count,
         "initial_count": initial_count,
         "added_auto_count": added_auto_count,
@@ -484,6 +501,7 @@ def main(
         "added_auto_iter_count": added_auto_iter_count,
         "added_adhoc_iter_count": added_adhoc_iter_count,
         "extra_count": extra_count,
+        "validation_count": validation_count,
     }
     arcann_logger.debug(f"training_json: {training_json}")
 
@@ -533,6 +551,9 @@ def main(
         training_json["decay_steps"],
     )
     while decay_rate_new < training_json["decay_rate"]:
+        arcann_logger.debug(
+            f"numb_steps is too small to allow for the decay_rate, increasing numb_steps: {decay_rate_new} < {training_json["decay_rate"]}"
+        )
         numb_steps = numb_steps + 10000
         decay_rate_new = calculate_decay_rate(
             numb_steps,
@@ -585,7 +606,17 @@ def main(
                 f"{localdata_path}",
             ]
         )
-    del dp_train_input_dataset, localdata_path, dp_train_input_datasets
+    del dp_train_input_dataset, dp_train_input_datasets
+    for dp_validate_input_dataset in dp_validate_input_datasets:
+        subprocess.run(
+            [
+                "rsync",
+                "-a",
+                f"{training_path / (dp_validate_input_dataset.rsplit('/', 1)[0])}",
+                f"{localdata_path}",
+            ]
+        )
+    del dp_validate_input_dataset, localdata_path, dp_validate_input_datasets
 
     # Change some inside output
     dp_train_input["training"]["disp_file"] = "lcurve.out"

--- a/arcann_training/training/prepare.py
+++ b/arcann_training/training/prepare.py
@@ -314,10 +314,9 @@ def main(
     del data_dir
 
     # TODO Implement validation dataset
-    # del validation_datasets
+    del validation_datasets
 
     # Training sets list construction
-    #TODO construct the same list for the validation dataset
     dp_train_input_datasets = []
     training_datasets = []
 
@@ -464,36 +463,20 @@ def main(
     else:
         del extra_datasets
 
-    # and the validation sets now
-    dp_validate_input_datasets = []
-    validation_count = 0
-    for validation_dataset in validation_datasets:
-        dp_validate_input_datasets.append(
-            f"{(Path(data_path.parts[-1]) / validation_dataset / '_')}"[:-1]
-        )
-        validation_count += np.load(
-            data_path / validation_dataset / "set.000" / "box.npy"
-        ).shape[0]
-        del validation_dataset
-
     # Total
     trained_count = initial_count + added_auto_count + added_adhoc_count + extra_count
     arcann_logger.debug(
         f"trained_count: {trained_count} = {initial_count} + {added_auto_count} + {added_adhoc_count} + {extra_count}"
     )
     arcann_logger.debug(f"dp_train_input_datasets: {dp_train_input_datasets}")
-    arcann_logger.debug(f"validation_count: {validation_count}")
-    arcann_logger.debug(f"dp_validate_input_datasets: {dp_validate_input_datasets}")
 
     # Update the inputs with the sets
     dp_train_input["training"]["training_data"]["systems"] = dp_train_input_datasets
-    dp_train_input["training"]["validation_data"]["systems"] = dp_validate_input_datasets
 
     # Update the training JSON
     training_json = {
         **training_json,
         "training_datasets": training_datasets,
-        "validation_datasets": validation_datasets,
         "trained_count": trained_count,
         "initial_count": initial_count,
         "added_auto_count": added_auto_count,
@@ -501,7 +484,6 @@ def main(
         "added_auto_iter_count": added_auto_iter_count,
         "added_adhoc_iter_count": added_adhoc_iter_count,
         "extra_count": extra_count,
-        "validation_count": validation_count,
     }
     arcann_logger.debug(f"training_json: {training_json}")
 
@@ -551,9 +533,6 @@ def main(
         training_json["decay_steps"],
     )
     while decay_rate_new < training_json["decay_rate"]:
-        arcann_logger.debug(
-            f"numb_steps is too small to allow for the decay_rate, increasing numb_steps: {decay_rate_new} < {training_json["decay_rate"]}"
-        )
         numb_steps = numb_steps + 10000
         decay_rate_new = calculate_decay_rate(
             numb_steps,
@@ -606,17 +585,7 @@ def main(
                 f"{localdata_path}",
             ]
         )
-    del dp_train_input_dataset, dp_train_input_datasets
-    for dp_validate_input_dataset in dp_validate_input_datasets:
-        subprocess.run(
-            [
-                "rsync",
-                "-a",
-                f"{training_path / (dp_validate_input_dataset.rsplit('/', 1)[0])}",
-                f"{localdata_path}",
-            ]
-        )
-    del dp_validate_input_dataset, localdata_path, dp_validate_input_datasets
+    del dp_train_input_dataset, localdata_path, dp_train_input_datasets
 
     # Change some inside output
     dp_train_input["training"]["disp_file"] = "lcurve.out"


### PR DESCRIPTION
### What does this PR do?

*(Briefly describe the main purpose of this PR in one or two sentences. What problem does it solve or what feature does it add?)*

Add the validation dataset handle for the first iteration. Meaning the validation set is understood and copied into the proper validation data directory to be used during deepmd training.
Does not handle the validation datasets created by the other iteration of the active circle. 

---

### How to test this?

*(Provide clear, step-by-step instructions on how the reviewer can manually test your changes.)*

1. Add a dataset under the DeepMD format named *test_SYSNAME* in the *data/* directory
2. Define test data in the *user_files/dptrain_2.1.json* :
```
 "training": {... 
        "validation_data": {
            "systems": "TEST_DATA",
            "set_prefix": "set",
            "batch_size": 5,
            "auto_prob": "prob_sys_size",
            "sys_probs": null }
```
3. Run the first training, this validation set will be used during the training, you'll be able to follow the validation loss in the *lcurve.out* file written by DeepMD.

No test implemented

---

### Related Issues/Tickets

*(Link to any relevant issues.)*

-- 