### PR TITLE
Add initial implementation of MACE integration into the initialization phase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,219 @@
+# Created by https://gitignore.org
+# Python.gitignore
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#   Usually these files are written by a python script from a template
+#   before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+# Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+# uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+# poetry.lock
+# poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+# pdm.lock
+# pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+# pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# Redis
+*.rdb
+*.aof
+*.pid
+
+# RabbitMQ
+mnesia/
+rabbitmq/
+rabbitmq-data/
+
+# ActiveMQ
+activemq-data/
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#   JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#   be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#   and can be added to the global gitignore or merged into this file.  For a more nuclear
+#   option (not recommended) you can uncomment the following to ignore the entire idea folder.
+# .idea/
+
+# Abstra
+#   Abstra is an AI-powered process automation framework.
+#   Ignore directories containing user credentials, local state, and settings.
+#   Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
+#   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#   and can be added to the global gitignore or merged into this file. However, if you prefer,
+#   you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml

--- a/arcann_training/assets/default_config.json
+++ b/arcann_training/assets/default_config.json
@@ -2,7 +2,8 @@
     "initialization":
     {
         "systems_auto": [""],
-        "nnp_count": 3
+        "nnp_count": 3,
+        "nnp_program": "deepmd"
     },
     "training":
     {

--- a/arcann_training/initialization/start.py
+++ b/arcann_training/initialization/start.py
@@ -25,16 +25,16 @@ from arcann_training.common.json import (
     load_json_file,
     write_json_file,
 )
+from arcann_training.common.utils import natural_sort_key
 from arcann_training.common.xyz import parse_xyz_trajectory_file
 from arcann_training.initialization.utils import (
-    generate_main_json,
-    check_properties_file,
     check_dptrain_properties,
+    check_extxyz_properties,
     check_lmp_properties,
+    check_properties_file,
     check_typeraw_properties,
-    check_extxyz_properties
+    generate_main_json,
 )
-from arcann_training.common.utils import natural_sort_key
 
 
 # Main function
@@ -49,7 +49,7 @@ def main(
     arcann_logger = logging.getLogger("ArcaNN")
 
     # Get the current path and set the training path as the current path
-    current_path = Path(".").resolve()
+    current_path = Path().resolve()
     training_path = current_path
     user_files_path = current_path / "user_files"
 
@@ -98,7 +98,7 @@ def main(
         list_of_lmp = [file.stem for file in user_files_path.glob("*.lmp")]
         if not list_of_lmp:
             arcann_logger.error(f"No lmp found in {user_files_path}")
-            arcann_logger.error(f"Aborting...")
+            arcann_logger.error("Aborting...")
             return 1
         list_of_lmp.sort(key=natural_sort_key)
         user_input_json["systems_auto"] = list_of_lmp
@@ -131,7 +131,7 @@ def main(
         user_input_json, default_input_json
     )
     arcann_logger.debug(f"main_json: {main_json}")
-    arcann_logger.debug(f"merged_input_json : {merged_input_json }")
+    arcann_logger.debug(f"merged_input_json : {merged_input_json}")
     arcann_logger.debug(f"padded_curr_iter : {padded_curr_iter}")
 
     nnp_program = main_json["nnp_program"]
@@ -152,14 +152,26 @@ def main(
         # Check the dptrain against the properties
         check_dptrain_properties(user_files_path, main_json["properties"])
     elif nnp_program == "mace":
-        if len(list(user_files_path.glob("mace_*.yml")) + list(user_files_path.glob("mace_*.yaml"))) == 0:
-            arcann_logger.error("MACE config file (mace_MACEVERSION.yml) is missing from user_files.")
+        if (
+            len(
+                list(user_files_path.glob("mace_*.yml"))
+                + list(user_files_path.glob("mace_*.yaml"))
+            )
+            == 0
+        ):
+            arcann_logger.error(
+                "MACE config file (mace_MACEVERSION.yml) is missing from user_files."
+            )
             arcann_logger.error("Aborting...")
             raise FileNotFoundError("MACE config file is missing from user_files.")
     else:
-        arcann_logger.error(f"NNP program: {nnp_program} not recognized. ArcaNN supports 'deepmd' or 'mace'.")
+        arcann_logger.error(
+            f"NNP program: {nnp_program} not recognized. ArcaNN supports 'deepmd' or 'mace'."
+        )
         arcann_logger.error("Aborting...")
-        raise ValueError(f"NNP program: {nnp_program} not recognized. ArcaNN supports 'deepmd' or 'mace'.")
+        raise ValueError(
+            f"NNP program: {nnp_program} not recognized. ArcaNN supports 'deepmd' or 'mace'."
+        )
 
     # Create the control directory
     control_path = training_path / "control"
@@ -196,8 +208,9 @@ def main(
             ).shape[0]
         elif nnp_program == "mace":
             check_extxyz_properties(initial_dataset_path)
-            initial_datasets_json[initial_dataset_path.name] = parse_xyz_trajectory_file(initial_dataset_path)[0].shape[0]
-
+            initial_datasets_json[initial_dataset_path.name] = (
+                parse_xyz_trajectory_file(initial_dataset_path)[0].shape[0]
+            )
 
     arcann_logger.debug(f"initial_datasets_json: {initial_datasets_json}")
     del initial_dataset_path, initial_datasets_paths, initial_dataset_set_path

--- a/arcann_training/initialization/start.py
+++ b/arcann_training/initialization/start.py
@@ -1,12 +1,12 @@
 """
 #----------------------------------------------------------------------------------------------------#
 #   ArcaNN: Automatic training of Reactive Chemical Architecture with Neural Networks                #
-#   Copyright 2022-2024 ArcaNN developers group <https://github.com/arcann-chem>                     #
+#   Copyright 2022-2025 ArcaNN developers group <https://github.com/arcann-chem>                     #
 #                                                                                                    #
 #   SPDX-License-Identifier: AGPL-3.0-only                                                           #
 #----------------------------------------------------------------------------------------------------#
 Created: 2022/01/01
-Last modified: 2024/05/15
+Last modified: 2025/12/16
 """
 
 # Standard library modules
@@ -25,12 +25,14 @@ from arcann_training.common.json import (
     load_json_file,
     write_json_file,
 )
+from arcann_training.common.xyz import parse_xyz_trajectory_file
 from arcann_training.initialization.utils import (
     generate_main_json,
     check_properties_file,
     check_dptrain_properties,
     check_lmp_properties,
     check_typeraw_properties,
+    check_extxyz_properties
 )
 from arcann_training.common.utils import natural_sort_key
 
@@ -56,7 +58,7 @@ def main(
     arcann_logger.debug(f"Current path: {current_path}")
     arcann_logger.debug(f"Training path: {training_path}")
     arcann_logger.debug(f"Program path: {deepmd_iterative_path}")
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
 
     # Load the default input JSON
     default_input_json = load_default_json_file(
@@ -105,22 +107,22 @@ def main(
         )
     elif "systems_auto" in user_input_json and user_input_json["systems_auto"]:
         if not isinstance(user_input_json["systems_auto"], list):
-            arcann_logger.error(f"'systems_auto' in the input JSON is not a list.")
-            arcann_logger.error(f"Aborting...")
+            arcann_logger.error("'systems_auto' in the input JSON is not a list.")
+            arcann_logger.error("Aborting...")
             return 1
         for system_auto in user_input_json["systems_auto"]:
             if not (user_files_path / f"{system_auto}.lmp").is_file():
                 arcann_logger.error(
                     f"File not found: {user_files_path / f'{system_auto}.lmp'} but requested as system"
                 )
-                arcann_logger.error(f"Aborting...")
+                arcann_logger.error("Aborting...")
                 return 1
         arcann_logger.info(
             f"Using 'systems_auto' from the input JSON: {user_input_json['systems_auto']}"
         )
     else:
-        arcann_logger.error(f"Empty 'systems_auto' in the input JSON.")
-        arcann_logger.error(f"Aborting...")
+        arcann_logger.error("Empty 'systems_auto' in the input JSON.")
+        arcann_logger.error("Aborting...")
         return 1
     arcann_logger.debug(f"user_input_json: {user_input_json}")
 
@@ -132,6 +134,11 @@ def main(
     arcann_logger.debug(f"merged_input_json : {merged_input_json }")
     arcann_logger.debug(f"padded_curr_iter : {padded_curr_iter}")
 
+    nnp_program = main_json["nnp_program"]
+
+    arcann_logger.info(f"Using {nnp_program} as NNP software")
+    arcann_logger.info("-" * 88)
+
     # Add the properties dictionary to the main JSON
     main_json["properties"] = properties_dict
 
@@ -141,8 +148,18 @@ def main(
             user_files_path / f"{system_auto}.lmp", main_json["properties"]
         )
 
-    # Check the dptrain against the properties
-    check_dptrain_properties(user_files_path, main_json["properties"])
+    if nnp_program == "deepmd":
+        # Check the dptrain against the properties
+        check_dptrain_properties(user_files_path, main_json["properties"])
+    elif nnp_program == "mace":
+        if len(list(user_files_path.glob("mace_*.yml")) + list(user_files_path.glob("mace_*.yaml"))) == 0:
+            arcann_logger.error("MACE config file (mace_MACEVERSION.yml) is missing from user_files.")
+            arcann_logger.error("Aborting...")
+            raise FileNotFoundError("MACE config file is missing from user_files.")
+    else:
+        arcann_logger.error(f"NNP program: {nnp_program} not recognized. ArcaNN supports 'deepmd' or 'mace'.")
+        arcann_logger.error("Aborting...")
+        raise ValueError(f"NNP program: {nnp_program} not recognized. ArcaNN supports 'deepmd' or 'mace'.")
 
     # Create the control directory
     control_path = training_path / "control"
@@ -156,26 +173,32 @@ def main(
     # Check if data exists, get init_* datasets and extract number of atoms and cell dimensions
     initial_datasets_paths = [_ for _ in (training_path / "data").glob("init_*")]
     if len(initial_datasets_paths) == 0:
-        arcann_logger.error(f"No initial datasets found.")
-        arcann_logger.error(f"Aborting...")
+        arcann_logger.error("No initial datasets found.")
+        arcann_logger.error("Aborting...")
         return 1
     arcann_logger.debug(f"initial_datasets_paths: {initial_datasets_paths}")
 
     # Create and set the initial datasets JSON
     initial_datasets_json = {}
     for initial_dataset_path in initial_datasets_paths:
-        check_file_existence(initial_dataset_path / "type.raw")
-        # Check the type.raw file against the properties
-        check_typeraw_properties(
-            initial_dataset_path / "type.raw", main_json["properties"]
-        )
-        initial_dataset_set_path = initial_dataset_path / "set.000"
-        for data_type in ["box", "coord", "energy", "force"]:
-            check_file_existence(initial_dataset_set_path / (data_type + ".npy"))
-        del data_type
-        initial_datasets_json[initial_dataset_path.name] = np.load(
-            initial_dataset_set_path / "box.npy"
-        ).shape[0]
+        if nnp_program == "deepmd":
+            check_file_existence(initial_dataset_path / "type.raw")
+            # Check the type.raw file against the properties
+            check_typeraw_properties(
+                initial_dataset_path / "type.raw", main_json["properties"]
+            )
+            initial_dataset_set_path = initial_dataset_path / "set.000"
+            for data_type in ["box", "coord", "energy", "force"]:
+                check_file_existence(initial_dataset_set_path / (data_type + ".npy"))
+            del data_type
+            initial_datasets_json[initial_dataset_path.name] = np.load(
+                initial_dataset_set_path / "box.npy"
+            ).shape[0]
+        elif nnp_program == "mace":
+            check_extxyz_properties(initial_dataset_path)
+            initial_datasets_json[initial_dataset_path.name] = parse_xyz_trajectory_file(initial_dataset_path)[0].shape[0]
+
+
     arcann_logger.debug(f"initial_datasets_json: {initial_datasets_json}")
     del initial_dataset_path, initial_datasets_paths, initial_dataset_set_path
 
@@ -189,7 +212,7 @@ def main(
     arcann_logger.debug(f"merged_input_json: {merged_input_json}")
 
     # Dump the JSON files (main, initial datasets and merged input)
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
     write_json_file(main_json, (control_path / "config.json"), read_only=True)
     write_json_file(
         initial_datasets_json, (control_path / "initial_datasets.json"), read_only=True
@@ -199,7 +222,7 @@ def main(
     )
 
     # End
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
     arcann_logger.info(f"Step: {current_step.capitalize()} is a success!")
 
     # Cleaning
@@ -214,7 +237,7 @@ def main(
     del padded_curr_iter
     del main_json, initial_datasets_json, merged_input_json
 
-    arcann_logger.debug(f"LOCAL")
+    arcann_logger.debug("LOCAL")
     arcann_logger.debug(f"{locals()}")
     return 0
 

--- a/arcann_training/initialization/utils.py
+++ b/arcann_training/initialization/utils.py
@@ -25,17 +25,18 @@ check_typeraw_properties(type_raw_path, properties_dict)
 # TODO: Homogenize the docstrings for this module
 
 # Standard library modules
-from pathlib import Path
 from copy import deepcopy
+from pathlib import Path
 from typing import Dict, Tuple
 
 # Third-party modules
 import numpy as np
 
+from arcann_training.common.json import load_json_file
+from arcann_training.common.lammps import read_lammps_data
+
 # Local imports
 from arcann_training.common.utils import catch_errors_decorator
-from arcann_training.common.lammps import read_lammps_data
-from arcann_training.common.json import load_json_file
 
 
 # Unittested
@@ -118,7 +119,6 @@ def check_properties_file(file_path: Path) -> dict:
     ValueError
         If the file structure is incorrect, or line formats in the 'type' or 'masses' sections are invalid.
     """
-
     if not file_path.exists():
         error_msg = f"File not found: {file_path}"
         raise FileNotFoundError(error_msg)
@@ -135,7 +135,7 @@ def check_properties_file(file_path: Path) -> dict:
 
     if type_index >= masses_index:
         error_msg = (
-            f"'type' section should come before 'masses'. Check your properties file."
+            "'type' section should come before 'masses'. Check your properties file."
         )
         raise ValueError(error_msg)
 
@@ -151,9 +151,9 @@ def check_properties_file(file_path: Path) -> dict:
         else:
             try:
                 types[parts[0]] = int(parts[1])
-            except ValueError:
+            except ValueError as err:
                 error_msg = f"Second part of line '{line}' in your 'type' section is not an integer. Check your properties file."
-                raise ValueError(error_msg)
+                raise ValueError(error_msg) from err
 
     # Process 'masses' section
     for line in lines[masses_index + 1 : masses_index + 1 + len(types)]:
@@ -164,13 +164,13 @@ def check_properties_file(file_path: Path) -> dict:
         else:
             try:
                 masses[parts[0]] = float(parts[1])
-            except ValueError:
+            except ValueError as err:
                 error_msg = f"Second part of line '{line}' in your 'masses' section is not an float. Check your properties file."
-                raise ValueError(error_msg)
+                raise ValueError(error_msg) from err
 
     if set(types) != set(masses):
         error_msg = (
-            f"Number of types and masses do not match. Check your properties file."
+            "Number of types and masses do not match. Check your properties file."
         )
         raise ValueError(error_msg)
 
@@ -205,7 +205,6 @@ def check_lmp_properties(lmp_file: Path, properties: Dict) -> bool:
     ValueError
         If there's a mismatch in atom types or their properties between the LAMMPS file and the properties dictionary.
     """
-
     num_atoms, num_atom_types, cell, masses, atoms = read_lammps_data(lmp_file)
     del num_atoms, cell, atoms
 
@@ -284,4 +283,4 @@ def check_extxyz_properties(extxyz_path: Path):
         missing.append("Energy")
 
     if not missing:
-        raise ValueError(f"XYZ file is missing {" and ".join(missing)} information.")
+        raise ValueError(f"XYZ file is missing {' and '.join(missing)} information.")

--- a/arcann_training/initialization/utils.py
+++ b/arcann_training/initialization/utils.py
@@ -1,7 +1,7 @@
 """
 #----------------------------------------------------------------------------------------------------#
 #   ArcaNN: Automatic training of Reactive Chemical Architecture with Neural Networks                #
-#   Copyright 2022-2024 ArcaNN developers group <https://github.com/arcann-chem>                     #
+#   Copyright 2022-2025 ArcaNN developers group <https://github.com/arcann-chem>                     #
 #                                                                                                    #
 #   SPDX-License-Identifier: AGPL-3.0-only                                                           #
 #----------------------------------------------------------------------------------------------------#
@@ -267,3 +267,21 @@ def check_typeraw_properties(type_raw_path, properties_dict):
         if type_val not in properties_dict:
             error_msg = f"Type {type_val} is not in properties file but is present in {type_raw_path}"
             raise ValueError(error_msg)
+
+
+@catch_errors_decorator
+def check_extxyz_properties(extxyz_path: Path):
+    with extxyz_path.open() as extxyz:
+        extxyz.readline()
+        comments = extxyz.readline()
+
+    missing = []
+
+    if "forces:R:3" not in comments:
+        missing.append("Forces")
+
+    if "energy:R:1" not in comments:
+        missing.append("Energy")
+
+    if not missing:
+        raise ValueError(f"XYZ file is missing {" and ".join(missing)} information.")

--- a/arcann_training/initialization/utils.py
+++ b/arcann_training/initialization/utils.py
@@ -32,10 +32,9 @@ from typing import Dict, Tuple
 # Third-party modules
 import numpy as np
 
+# Local imports
 from arcann_training.common.json import load_json_file
 from arcann_training.common.lammps import read_lammps_data
-
-# Local imports
 from arcann_training.common.utils import catch_errors_decorator
 
 

--- a/arcann_training/unittests/test_utils_initlialization.py
+++ b/arcann_training/unittests/test_utils_initlialization.py
@@ -25,8 +25,8 @@ from pathlib import Path
 
 # Local imports
 from arcann_training.initialization.utils import (
-    generate_main_json,
     check_properties_file,
+    generate_main_json,
 )
 
 
@@ -50,6 +50,7 @@ class TestGenerateMainJson(unittest.TestCase):
         self.default_json = {
             "systems_auto": [""],
             "nnp_count": 3,
+            "nnp_program": "deepmd",
         }
 
     def test_generate_main_json_with_valid_input(self):
@@ -59,16 +60,19 @@ class TestGenerateMainJson(unittest.TestCase):
         input_json = {
             "systems_auto": ["subsys1", "subsys2"],
             "nnp_count": 5,
+            "nnp_program": "mace",
         }
 
         expected_config_json = {
             "systems_auto": {"subsys1": {"index": 0}, "subsys2": {"index": 1}},
             "nnp_count": 5,
+            "nnp_program": "mace",
             "current_iteration": 0,
         }
         expected_merged_input_json = {
             "systems_auto": ["subsys1", "subsys2"],
             "nnp_count": 5,
+            "nnp_program": "mace",
         }
         expected_padded_curr_iter = "000"
 
@@ -91,11 +95,13 @@ class TestGenerateMainJson(unittest.TestCase):
         expected_config_json = {
             "systems_auto": {"subsys1": {"index": 0}, "subsys2": {"index": 1}},
             "nnp_count": 3,
+            "nnp_program": "deepmd",
             "current_iteration": 0,
         }
         expected_merged_input_json = {
             "systems_auto": ["subsys1", "subsys2"],
             "nnp_count": 3,
+            "nnp_program": "deepmd",
         }
         expected_padded_curr_iter = "000"
 
@@ -114,6 +120,7 @@ class TestGenerateMainJson(unittest.TestCase):
         input_json = {
             "systems_auto": ["subsys1", 2],
             "nnp_count": "not a number",
+            "nnp_program": "not a string",
         }
 
         with self.assertRaises(TypeError):
@@ -126,6 +133,7 @@ class TestGenerateMainJson(unittest.TestCase):
         input_json = {
             "systems_auto": ["subsys1", 2],
             "nnp_count": 2,
+            "nnp_program": "deepmd",
         }
 
         with self.assertRaises(TypeError):
@@ -162,7 +170,7 @@ class TestCheckPropertiesFile(unittest.TestCase):
 
     def create_temp_file(self, content):
         temp_file = Path(self.test_dir.name) / "temp_properties_file.txt"
-        with open(temp_file, "w") as file:
+        with temp_file.open("w") as file:
             file.write(content)
         return temp_file
 


### PR DESCRIPTION
### What does this PR do?

*(Briefly describe the main purpose of this PR in one or two sentences. What problem does it solve or what feature does it add?)*

This PR adds support for selecting the Neural Network Potential (NNP) backend via the configuration file.

Specifically, it introduces a new `nnp_program` field that allows users to choose which NNP software to use (`deepmd` or `mace`). During the initialization phase, additional checks are performed to correctly handle program-specific initial dataset formats. When using MACE, a corresponding `mace_<MACEVERSION>.yaml` configuration file is also required.

---

### How to test this?

1. Define the NNP program in the configuration file:
   ```json
   "initialization": {
       "nnp_program": "deepmd" // or "mace"
   }
2. Place the initial dataset in the data/ directory using the correct format for the selected NNP program.
3. If using MACE, ensure a mace_<MACEVERSION>.yaml configuration file is present in the user_files/ directory.
4. Run the initialization step.

Notes:
- No new tests were added.
- Existing initialization-related tests were updated in test_utils_initialization.py to reflect the new configuration option.

---

### Related Issues/Tickets

*(Link to any relevant issues.)*

-- 