### PR TITLE
FEAT: MACE can be used for training

### DIFF
--- a/arcann_training/assets/default_config.json
+++ b/arcann_training/assets/default_config.json
@@ -25,7 +25,7 @@
         "decay_steps": 5000,
         "decay_steps_fixed": false,
         "numb_steps": 400000,
-        "max_num_epochs": 5000,
+        "max_num_epochs": 500,
         "numb_test": 0
     },
     "exploration":

--- a/arcann_training/assets/default_config.json
+++ b/arcann_training/assets/default_config.json
@@ -25,6 +25,7 @@
         "decay_steps": 5000,
         "decay_steps_fixed": false,
         "numb_steps": 400000,
+        "max_num_epochs": 5000,
         "numb_test": 0
     },
     "exploration":

--- a/arcann_training/common/dataset.py
+++ b/arcann_training/common/dataset.py
@@ -25,21 +25,22 @@ from arcann_training.initialization.utils import check_typeraw_properties
 
 arcann_logger = logging.getLogger("ArcaNN")
 
-class DataEnsemble():
+
+class DataEnsemble:
     """
     Class defining an ensemble of data (understand a set of initial, or relabeled data)
 
     Attributes:
     ----------
         path (Path): Path to the data ensemble
-        step (Literal["initial", "extra", "system_auto", "system_adhoc", "system_disturbed"]): 
+        step (Literal["initial", "extra", "system_auto", "system_adhoc", "system_disturbed"]):
             Type of the data ensemble in the step of the arcann workflow
         training_type (Literal["training", "validation"]): Whether the data ensemble is used for training or validation
         system_name (str | None): Name of the system from which the data ensemble originates. None if not applicable
         iteration (int | None): Iteration (of arcann) number from which the data ensemble originates. None if not applicable
         data_format (Literal["extxyz", "set.000"]): Type of data ensemble
         properties (Dict[int, Dict[str, str | float]]): Properties associated with the data ensemble
-    
+
     Methods:
     --------
         to_dict(): Convert the data ensemble to a dictionary
@@ -49,17 +50,24 @@ class DataEnsemble():
         get_extxyz(): Get the data under the extxyz format
         get_set000(): Get the data under the set.000 format
     """
+
     def __init__(
         self,
         path: str | Path,
-        step: Literal["initial", "extra", "system_auto", "system_adhoc", "system_disturbed"],
+        step: Literal[
+            "initial", "extra", "system_auto", "system_adhoc", "system_disturbed"
+        ],
         training_type: Literal["training", "validation", "test"],
         system_name: str | None,
         iteration: int | None,
         data_format: Literal["extxyz", "set.000"],
         properties: Dict[int, Dict[str, str | float]],
     ):
-        check_directory(Path(path), abort_on_error=True, error_msg="The provided data path does not exist.")
+        check_directory(
+            Path(path),
+            abort_on_error=True,
+            error_msg="The provided data path does not exist.",
+        )
         self.path = Path(path)
         self.step = step
         self.training_type = training_type
@@ -67,9 +75,9 @@ class DataEnsemble():
         self.iteration = iteration
 
         self.data_format = data_format
-        self.properties = {int(k): v for k,v in properties.items()}
+        self.properties = {int(k): v for k, v in properties.items()}
 
-        self.size = None 
+        self.size = None
 
         # proper data
         self.type = None
@@ -96,7 +104,7 @@ class DataEnsemble():
 
     def check_format(self):
         raise NotImplementedError
-    
+
     def get_size(self):
         raise NotImplementedError
 
@@ -130,49 +138,61 @@ class DataEnsemble():
     def write(self):
         raise NotImplementedError
 
+
 class Set000Ensemble(DataEnsemble):
     """Define a data ensemble in the set.000 format"""
-    def __init__(self, path, step, training_type, system_name, iteration, data_format, properties):
-        super().__init__(path, step, training_type, system_name, iteration, data_format, properties)
+
+    def __init__(
+        self, path, step, training_type, system_name, iteration, data_format, properties
+    ):
+        super().__init__(
+            path, step, training_type, system_name, iteration, data_format, properties
+        )
         if data_format != "set.000":
             raise ValueError("Data type must be 'set.000' for Set000Ensemble")
         self.size = self.get_size()
 
-
     def check_format(self) -> None:
         """
-        Check the format of the data ensemble by checking the existence of all the files and the consistency 
+        Check the format of the data ensemble by checking the existence of all the files and the consistency
         of the type.raw file with the properties
         """
         check_file_existence(self.path / "type.raw")
-        check_typeraw_properties(
-            self.path / "type.raw", self.properties
-        )
+        check_typeraw_properties(self.path / "type.raw", self.properties)
         set_path = self.path / "set.000"
         for data_type in ["box", "coord", "energy", "force"]:
             check_file_existence(set_path / (data_type + ".npy"))
-
 
     def get_size(self) -> int | None:
         if (self.path / "set.000" / "box.npy").is_file():
             return np.load(self.path / "set.000" / "box.npy").shape[0]
         return None
 
-
     def load(self) -> None:
         """Load the data of the ensemble in the attributes"""
         self.check_format()
         self.type = np.loadtxt(self.path / "type.raw", dtype=int)
-        self.box =  np.load(self.path / "set.000" / "box.npy")
+        self.box = np.load(self.path / "set.000" / "box.npy")
         self.coord = np.load(self.path / "set.000" / "coord.npy")
         self.energy = np.load(self.path / "set.000" / "energy.npy")
         self.force = np.load(self.path / "set.000" / "force.npy")
-        self.virial = np.load(self.path / "set.000" / "virial.npy") if (self.path / "set.000" / "virial.npy").is_file() else None
-        self.wannier = np.load(self.path / "set.000" / "wannier.npy") if (self.path / "set.000" / "wannier.npy").is_file() else None
+        self.virial = (
+            np.load(self.path / "set.000" / "virial.npy")
+            if (self.path / "set.000" / "virial.npy").is_file()
+            else None
+        )
+        self.wannier = (
+            np.load(self.path / "set.000" / "wannier.npy")
+            if (self.path / "set.000" / "wannier.npy").is_file()
+            else None
+        )
         self.is_periodic = not (self.path / "nopbc").is_file()
-        self.wannier_not_cvg = textfile_to_string_list(self.path / "set.000" / "wannier-not-converged.txt") if (self.path / "set.000" / "wannier-not-converged.txt").is_file() else []
+        self.wannier_not_cvg = (
+            textfile_to_string_list(self.path / "set.000" / "wannier-not-converged.txt")
+            if (self.path / "set.000" / "wannier-not-converged.txt").is_file()
+            else []
+        )
         self.size = self.get_size()
-
 
     def write(self):
         """Write the data of the ensemble in the set.000 format from the attributes"""
@@ -185,61 +205,73 @@ class Set000Ensemble(DataEnsemble):
         if self.virial:
             np.save(self.path / "set.000" / "virial.npy", self.virial)
         if self.wannier:
-            np.save(self.path / "set.000" / "wannier.npy", self.wannier)      
+            np.save(self.path / "set.000" / "wannier.npy", self.wannier)
         if self.is_periodic is not None and not self.is_periodic:
-            np.savetxt(self.path / "nopbc", np.array([True]), fmt="%s") 
+            np.savetxt(self.path / "nopbc", np.array([True]), fmt="%s")
         if len(self.wannier_not_cvg) > 1:
-            string_list_to_textfile(self.path / "set.000" / "wannier-not-converged.txt", self.wannier_not_cvg)
-
+            string_list_to_textfile(
+                self.path / "set.000" / "wannier-not-converged.txt",
+                self.wannier_not_cvg,
+            )
 
     def to_extxyz(self, save: bool = False) -> list[ase.Atoms]:
         """
-        Convert the attributes data into a list of ASE Atoms objects and optionally 
+        Convert the attributes data into a list of ASE Atoms objects and optionally
         save this trajectory in the extxyz format.
         """
-        elements = [self.properties[int(tp)+1]["symbol"] for tp in self.type]
+        self.load()
+        elements = [self.properties[int(tp) + 1]["symbol"] for tp in self.type]
         frames = []
         for i in range(self.size):
             frame = ase.Atoms(
                 symbols=elements,
                 positions=self.coord[i].reshape(-1, 3),
                 cell=self.box[i].reshape(3, 3),
-                pbc = self.is_periodic,
+                pbc=self.is_periodic,
             )
             frame.info["REF_energy"] = np.array([float(self.energy[i])])
             frame.arrays["REF_forces"] = self.force[i].reshape(-1, 3)
             if self.virial is not None:
-                frame.info["REF_virial"] = self.virial[i].reshape(3, 3)
+                frame.info["REF_virials"] = self.virial[i].reshape(3, 3)
             frames.append(frame)
 
         if save:
             with (self.path / f"{self.path.name}.extxyz").open("w+") as f:
                 write_extxyz(f, frames)
             if self.wannier is not None:
-                np.save(self.path / "wannier.npy", self.wannier)              
+                np.save(self.path / "wannier.npy", self.wannier)
         return frames
 
-    
+
 class ExtXYZEnsemble(DataEnsemble):
     """Define a data ensemble in the extxyz format"""
-    def __init__(self, path, step, training_type, system_name, iteration, data_format, properties):
-        super().__init__(path, step, training_type, system_name, iteration, data_format, properties)
+
+    def __init__(
+        self, path, step, training_type, system_name, iteration, data_format, properties
+    ):
+        super().__init__(
+            path, step, training_type, system_name, iteration, data_format, properties
+        )
         if data_format != "extxyz":
             raise ValueError("Data type must be 'extxyz' for ExtXYZEnsemble")
         self.size = self.get_size()
 
-
-    def check_format(self) -> None:
-        """Check the format of the data ensemble by checking the existence of the extxyz file and 
+    def check_format(
+        self, forces_keyword="REF_forces", energy_keyword="REF_energy"
+    ) -> None:
+        """Check the format of the data ensemble by checking the existence of the extxyz file and
         the presence of forces and energy in each frame of the trajectory.
         """
         check_file_existence(self.path / f"{self.path.name}.extxyz")
         trajectory = read(self.path / f"{self.path.name}.extxyz", index=":")
-        if "REF_forces" not in trajectory[0].arrays:
-            raise ValueError(f"The extxyz file {self.path / f'{self.path.name}.extxyz'} does not contain forces in the arrays.")
-        if "REF_energy" not in trajectory[0].info:
-            raise ValueError(f"The extxyz file {self.path / f'{self.path.name}.extxyz'} does not contain energy.")
-
+        if forces_keyword not in trajectory[0].arrays:
+            raise ValueError(
+                f"The extxyz file {self.path / f'{self.path.name}.extxyz'} does not contain forces in the arrays."
+            )
+        if energy_keyword not in trajectory[0].info:
+            raise ValueError(
+                f"The extxyz file {self.path / f'{self.path.name}.extxyz'} does not contain energy."
+            )
 
     def get_size(self) -> int | None:
         if (self.path / f"{self.path.name}.extxyz").is_file():
@@ -247,58 +279,90 @@ class ExtXYZEnsemble(DataEnsemble):
             return len(list(trajectory))
         return None
 
-
     def load(self) -> None:
         """Load the data of the ensemble in the attributes"""
         self.check_format()
         trajectory = read(self.path / f"{self.path.name}.extxyz", index=":")
         self.box = np.array([atoms.get_cell().reshape(-1) for atoms in trajectory])
-        self.coord = np.array([atoms.get_positions().reshape(-1) for atoms in trajectory])
-        self.force = np.array([atoms.arrays["REF_forces"].reshape(-1) for atoms in trajectory])
+        self.coord = np.array(
+            [atoms.get_positions().reshape(-1) for atoms in trajectory]
+        )
+        self.force = np.array(
+            [atoms.arrays["REF_forces"].reshape(-1) for atoms in trajectory]
+        )
         self.energy = np.array([atoms.info["REF_energy"] for atoms in trajectory])
 
-        self.virial = np.array([atoms.info["REF_virial"].reshape(-1) for atoms in trajectory]) if "virial" in trajectory[0].info else None
-        self.wannier = np.load(self.path / "wannier.npy") if (self.path / "wannier.npy").is_file() else None
+        self.virial = (
+            np.array([atoms.info["REF_virials"].reshape(-1) for atoms in trajectory])
+            if "virial" in trajectory[0].info
+            else None
+        )
+        self.wannier = (
+            np.load(self.path / "wannier.npy")
+            if (self.path / "wannier.npy").is_file()
+            else None
+        )
 
         self.is_periodic = trajectory[0].get_pbc()
-        self.type = np.array([int(k)-1 for elm in trajectory[0].get_chemical_symbols() for k, v in self.properties.items() if v["symbol"]==elm])
-        self.wannier_not_cvg = textfile_to_string_list(self.path / "wannier-not-converged.txt") if (self.path / "wannier-not-converged.txt").is_file() else []
+        self.type = np.array(
+            [
+                int(k) - 1
+                for elm in trajectory[0].get_chemical_symbols()
+                for k, v in self.properties.items()
+                if v["symbol"] == elm
+            ]
+        )
+        self.wannier_not_cvg = (
+            textfile_to_string_list(self.path / "wannier-not-converged.txt")
+            if (self.path / "wannier-not-converged.txt").is_file()
+            else []
+        )
         self.size = self.get_size()
-    
+        return trajectory
 
     def write(self) -> None:
         """
-        Write the data of the ensemble in the extxyz format from the attributes by converting 
-        them into a list of ASE Atoms objects saved as a extxyz trajectory. 
+        Write the data of the ensemble in the extxyz format from the attributes by converting
+        them into a list of ASE Atoms objects saved as a extxyz trajectory.
         """
-        elements = [self.properties[int(tp)+1]["symbol"] for tp in self.type]
+        elements = [self.properties[int(tp) + 1]["symbol"] for tp in self.type]
         frames = []
         for i in range(self.size):
             frame = ase.Atoms(
                 symbols=elements,
                 positions=self.coord[i].reshape(-1, 3),
                 cell=self.box[i].reshape(3, 3),
-                pbc = self.is_periodic,
+                pbc=self.is_periodic,
             )
             frame.info["REF_energy"] = np.array([float(self.energy[i])])
             frame.arrays["REF_forces"] = self.force[i].reshape(-1, 3)
             if self.virial is not None:
-                frame.info["REF_virial"] = self.virial[i].reshape(3, 3)
+                frame.info["REF_virials"] = self.virial[i].reshape(3, 3)
             frames.append(frame)
 
         if self.is_periodic is not None and not self.is_periodic:
-            np.savetxt(self.path / "nopbc", np.array([True]), fmt="%s") 
+            np.savetxt(self.path / "nopbc", np.array([True]), fmt="%s")
         if self.wannier:
-            np.save(self.path / "wannier.npy", self.wannier)      
+            np.save(self.path / "wannier.npy", self.wannier)
         if len(self.wannier_not_cvg) > 1:
-            string_list_to_textfile(self.path  / "wannier-not-converged.txt", self.wannier_not_cvg)
+            string_list_to_textfile(
+                self.path / "wannier-not-converged.txt", self.wannier_not_cvg
+            )
 
         with (self.path / f"{self.path.name}.extxyz").open("w+") as f:
             write_extxyz(f, frames)
 
+    def to_extxyz(self, save: bool = False) -> list[ase.Atoms]:
+        """Return the data of the ensemble in the extxyz format as a list of ASE Atoms objects.
+        If save is True, save the trajectory in the extxyz format."""
+        if save:
+            self.write()
+        return self.load()
 
     def to_set000(self):
         """Convert the data of the ensemble in the set.000 format by writing the corresponding files from the attributes."""
+        self.load()
+
         np.savetxt(self.path / "type.raw", self.type, fmt="%s")
         (self.path / "set.000").mkdir(parents=True, exist_ok=True)
         np.save(self.path / "set.000" / "box.npy", self.box)
@@ -308,18 +372,20 @@ class ExtXYZEnsemble(DataEnsemble):
         if self.virial:
             np.save(self.path / "set.000" / "virial.npy", self.virial)
         if self.wannier:
-            np.save(self.path / "set.000" / "wannier.npy", self.wannier)      
+            np.save(self.path / "set.000" / "wannier.npy", self.wannier)
         if self.is_periodic is not None and not self.is_periodic:
-            np.savetxt(self.path / "nopbc", np.array([True]), fmt="%s") 
+            np.savetxt(self.path / "nopbc", np.array([True]), fmt="%s")
         if len(self.wannier_not_cvg) > 1:
-            string_list_to_textfile(self.path / "set.000" / "wannier-not-converged.txt", self.wannier_not_cvg)
+            string_list_to_textfile(
+                self.path / "set.000" / "wannier-not-converged.txt",
+                self.wannier_not_cvg,
+            )
 
 
-
-class Dataset():
+class Dataset:
     """
     Class defining the dataset used for training and validation, as a list of DataEnsemble objects.
-    Each DataEnsemble corresponds to a set of data (initial or relabeled from a specific system md 
+    Each DataEnsemble corresponds to a set of data (initial or relabeled from a specific system md
     simulation etc..) stored in a specific format (extxyz or set.000).
 
     Attributes:
@@ -332,7 +398,7 @@ class Dataset():
         dataset_dir (Path): Path to the dataset directory
         data_format (Literal["extxyz", "set.000"]): Type of data ensemble
         data_ensemble (DataEnsemble): Class of the data ensembles
-    
+
     Methods:
     --------
         get_training_dataset(): Get the training data ensembles
@@ -343,6 +409,7 @@ class Dataset():
         init_config_file(): Initialize the control file
         update_config_file(): Update the control file
     """
+
     def __init__(
         self,
         training_dir: str | Path,
@@ -354,13 +421,19 @@ class Dataset():
         self.training_paths = []
         self.validation_paths = []
 
-        self.control_file = load_json_file(training_dir / "control" / "dataset.json", abort_on_error=False)
+        self.control_file = load_json_file(
+            training_dir / "control" / "dataset.json", abort_on_error=False
+        )
         self.control_file.setdefault("used_datasets", {})
         self.config_file = config_file
         self.split = self.config_file["validation/training_split"]
         self.dataset_dir = Path(training_dir) / "data"
-        check_directory(self.dataset_dir, abort_on_error=True, error_msg="The provided dataset directory does not exist.")
-        self.init_data_format() #get data type and data ensemble class
+        check_directory(
+            self.dataset_dir,
+            abort_on_error=True,
+            error_msg="The provided dataset directory does not exist.",
+        )
+        self.init_data_format()  # get data type and data ensemble class
 
     def __str__(self):
         pass
@@ -372,7 +445,7 @@ class Dataset():
         raise NotImplementedError
 
     def init_data_format(self) -> None:
-        """From the directory of the dataset, identify the extxyz or set.000 format"""    
+        """From the directory of the dataset, identify the extxyz or set.000 format"""
         provided_format = self.config_file["data_format"]
         if provided_format == "set.000":
             self.data_format = "set.000"
@@ -381,7 +454,9 @@ class Dataset():
             self.data_format = "extxyz"
             self.data_ensemble = ExtXYZEnsemble
         else:
-            raise ValueError(f"The provided data format {provided_format} is not recognized. Please use 'set.000' or 'extxyz'.")
+            raise ValueError(
+                f"The provided data format {provided_format} is not recognized. Please use 'set.000' or 'extxyz'."
+            )
 
         # datasets = os.listdir(self.dataset_dir)
         # for dataset in datasets:
@@ -390,48 +465,62 @@ class Dataset():
         #         if (dataset_path / "set.000").is_dir() and self.data_format != "set.000":
         #             self.convert
         #         elif any(file.suffix == ".extxyz" for file in dataset_path.glob("*.extxyz")):
-            
 
     def read_dataset(self) -> Union[int, int]:
         """Read the datasets from the already processed datasets in the control file"""
 
         self.training_dataset = {
-            key: self.data_ensemble(**kwargs) for key, kwargs in self.control_file["used_datasets"]["training"].items()
+            key: self.data_ensemble(**kwargs)
+            for key, kwargs in self.control_file["used_datasets"]["training"].items()
         }
         self.training_paths = list(self.training_dataset.keys())
         self.validation_dataset = {
-            key: self.data_ensemble(**kwargs) for key, kwargs in self.control_file["used_datasets"]["validation"].items()
+            key: self.data_ensemble(**kwargs)
+            for key, kwargs in self.control_file["used_datasets"]["validation"].items()
         }
         self.validation_paths = list(self.validation_dataset.keys())
 
-    def load_dataset(self, extra_dataset: bool=True, init_dataset: bool=True, only_init: bool=False) -> Union[int, int, int]:
+    def load_dataset(
+        self,
+        extra_dataset: bool = True,
+        init_dataset: bool = True,
+        only_init: bool = False,
+    ) -> Union[int, int, int]:
         """Load the new dataensembles from the dataset directory, depending on the control file information"""
-        #TODO this function has to go!!!
-        dataset_names = self.training_paths + self.validation_paths  #already existing/treated data ensembles
+        # TODO this function has to go!!!
+        dataset_names = (
+            self.training_paths + self.validation_paths
+        )  # already existing/treated data ensembles
         common_kwargs = {
             "data_format": self.data_format,
             "properties": self.config_file["properties"],
-        } #attributes common to all data ensembles
+        }  # attributes common to all data ensembles
 
         system_count, system_val_count, adhoc_count, adhoc_val_count = 0, 0, 0, 0
 
-        #Read the NEW data ensembles
+        # Read the NEW data ensembles
         for datadir in self.dataset_dir.iterdir():
             if datadir.is_dir() and datadir.name not in dataset_names:
                 step, system_name, iteration = None, None, None
-                if datadir.name.startswith("extra_") and extra_dataset and not only_init:
-                    #case of extra datasets
+                if (
+                    datadir.name.startswith("extra_")
+                    and extra_dataset
+                    and not only_init
+                ):
+                    # case of extra datasets
                     step = "extra"
-                
+
                 elif datadir.name.startswith("init_") and (init_dataset or only_init):
-                    #case of initial datasets
+                    # case of initial datasets
                     step = "initial"
 
                 elif not only_init:
-                    #case of system datasets
+                    # case of system datasets
                     system_name, iteration = datadir.name.rsplit("_", 1)
                     system_name = system_name.removesuffix("_valid")
-                    arcann_logger.debug(f"Loading dataset from system {system_name} at iteration {iteration} from {datadir.name}")
+                    arcann_logger.debug(
+                        f"Loading dataset from system {system_name} at iteration {iteration} from {datadir.name}"
+                    )
                     iteration = int(iteration)
                     if system_name in self.config_file["systems_auto"]:
                         step = "system_auto"
@@ -439,7 +528,11 @@ class Dataset():
                             system_val_count += 1
                         else:
                             system_count += 1
-                    elif "-disturbed" in system_name and system_name.removesuffix("-disturbed") in self.config_file["systems_adhoc"]:
+                    elif (
+                        "-disturbed" in system_name
+                        and system_name.removesuffix("-disturbed")
+                        in self.config_file["systems_adhoc"]
+                    ):
                         step = "system_disturbed"
                         if "valid" in datadir.name:
                             system_val_count += 1
@@ -455,11 +548,21 @@ class Dataset():
                 if step:
                     if "valid" in datadir.name:
                         self.validation_dataset[datadir.name] = self.data_ensemble(
-                            path=datadir, step=step, training_type="validation", system_name=system_name, iteration=iteration, **common_kwargs
+                            path=datadir,
+                            step=step,
+                            training_type="validation",
+                            system_name=system_name,
+                            iteration=iteration,
+                            **common_kwargs,
                         )
                     else:
                         self.training_dataset[datadir.name] = self.data_ensemble(
-                            path=datadir, step=step, training_type="training", system_name=system_name, iteration=iteration, **common_kwargs
+                            path=datadir,
+                            step=step,
+                            training_type="training",
+                            system_name=system_name,
+                            iteration=iteration,
+                            **common_kwargs,
                         )
         self.training_paths = list(self.training_dataset.keys())
         self.validation_paths = list(self.validation_dataset.keys())
@@ -471,24 +574,27 @@ class Dataset():
             dataset.check_format()
         for dataset in self.validation_dataset.values():
             dataset.check_format()
-        
+
         if len(self.training_dataset) != len(self.training_paths):
             raise ValueError("Mismatch between training dataset and training paths")
         if len(self.validation_dataset) != len(self.validation_paths):
             raise ValueError("Mismatch between validation dataset and validation paths")
 
-    def remove_datasets(self, init_dataset:bool = True):
+    def remove_datasets(self, init_dataset: bool = True):
         if init_dataset:
-            #remove the initial datasets
+            # remove the initial datasets
             self.training_dataset = {
-                key: dataset for key, dataset in self.training_dataset.items() if dataset.step != "initial"
+                key: dataset
+                for key, dataset in self.training_dataset.items()
+                if dataset.step != "initial"
             }
             self.validation_dataset = {
-                key: dataset for key, dataset in self.validation_dataset.items() if dataset.step != "initial"
+                key: dataset
+                for key, dataset in self.validation_dataset.items()
+                if dataset.step != "initial"
             }
             self.training_paths = list(self.training_dataset.keys())
             self.validation_paths = list(self.validation_dataset.keys())
-        
 
     def add_system_dataset(
         self,
@@ -521,8 +627,12 @@ class Dataset():
             "data_format": self.data_format,
             "properties": self.config_file["properties"],
         }
-        training_data_ensemble = self.data_ensemble(path=training_dir, training_type="training", **common_kwargs)
-        validation_data_ensemble = self.data_ensemble(path=validation_dir, training_type="validation", **common_kwargs)
+        training_data_ensemble = self.data_ensemble(
+            path=training_dir, training_type="training", **common_kwargs
+        )
+        validation_data_ensemble = self.data_ensemble(
+            path=validation_dir, training_type="validation", **common_kwargs
+        )
 
         nb_of_frames = coord.shape[0]
         indices = np.random.permutation(nb_of_frames)
@@ -537,12 +647,28 @@ class Dataset():
             "virial": virial,
             "wannier": wannier,
         }
-        train_arrays = {name: arr[train_idx] if arr is not None else None for name,arr in arrays.items()}
-        val_arrays   = {name: arr[val_idx] if arr is not None else None for name,arr in arrays.items()}
-        #TODO probably these wannier not cvg should be splitted too but i dunno how
-        training_data_ensemble.load_from_raw_arrays(type=type, **train_arrays, wannier_not_cvg=wannier_not_cvg, is_periodic=is_periodic)
-        training_data_ensemble.write() 
-        validation_data_ensemble.load_from_raw_arrays(type=type, **val_arrays, wannier_not_cvg=wannier_not_cvg, is_periodic=is_periodic)
+        train_arrays = {
+            name: arr[train_idx] if arr is not None else None
+            for name, arr in arrays.items()
+        }
+        val_arrays = {
+            name: arr[val_idx] if arr is not None else None
+            for name, arr in arrays.items()
+        }
+        # TODO probably these wannier not cvg should be splitted too but i dunno how
+        training_data_ensemble.load_from_raw_arrays(
+            type=type,
+            **train_arrays,
+            wannier_not_cvg=wannier_not_cvg,
+            is_periodic=is_periodic,
+        )
+        training_data_ensemble.write()
+        validation_data_ensemble.load_from_raw_arrays(
+            type=type,
+            **val_arrays,
+            wannier_not_cvg=wannier_not_cvg,
+            is_periodic=is_periodic,
+        )
         validation_data_ensemble.write()
 
         self.control_file.setdefault("intermediate_datasets", {})
@@ -551,38 +677,133 @@ class Dataset():
             validation_dir.name: validation_data_ensemble.size,
         }
 
-        #TODO at some point, we should add this new data ensemble that we creating to the dict so that they are 
-        #saved to the control file as system dataset and read at the next iteration without having to check if
-        #they are new of not
+        # TODO at some point, we should add this new data ensemble that we creating to the dict so that they are
+        # saved to the control file as system dataset and read at the next iteration without having to check if
+        # they are new of not
 
     def update_control_file(self):
-        #Write the LOADED new data ensembles to the control file and save it
+        # Write the LOADED new data ensembles to the control file and save it
         # Be careful to not use that without having loaded the dataset first!!
         self.control_file["initial_datasets"] = {
-            **{key: dataset.size for key, dataset in self.training_dataset.items() if dataset.step == "initial"},
-            **{key: dataset.size for key, dataset in self.validation_dataset.items() if dataset.step == "initial"},
+            **{
+                key: dataset.size
+                for key, dataset in self.training_dataset.items()
+                if dataset.step == "initial"
+            },
+            **{
+                key: dataset.size
+                for key, dataset in self.validation_dataset.items()
+                if dataset.step == "initial"
+            },
         }
         self.control_file["system_datasets"] = {
-            **{key: dataset.size for key, dataset in self.training_dataset.items() if dataset.step in ["system_auto", "system_disturbed"]},
-            **{key: dataset.size for key, dataset in self.validation_dataset.items() if dataset.step in ["system_auto", "system_disturbed"]},
+            **{
+                key: dataset.size
+                for key, dataset in self.training_dataset.items()
+                if dataset.step in ["system_auto", "system_disturbed"]
+            },
+            **{
+                key: dataset.size
+                for key, dataset in self.validation_dataset.items()
+                if dataset.step in ["system_auto", "system_disturbed"]
+            },
         }
         self.control_file["extra_datasets"] = {
-            **{key: dataset.size for key, dataset in self.training_dataset.items() if dataset.step == "extra"},
-            **{key: dataset.size for key, dataset in self.validation_dataset.items() if dataset.step == "extra"},
+            **{
+                key: dataset.size
+                for key, dataset in self.training_dataset.items()
+                if dataset.step == "extra"
+            },
+            **{
+                key: dataset.size
+                for key, dataset in self.validation_dataset.items()
+                if dataset.step == "extra"
+            },
         }
         self.control_file["adhoc_datasets"] = {
-            **{key: dataset.size for key, dataset in self.training_dataset.items() if dataset.step == "system_adhoc"},
-            **{key: dataset.size for key, dataset in self.validation_dataset.items() if dataset.step == "system_adhoc"},
+            **{
+                key: dataset.size
+                for key, dataset in self.training_dataset.items()
+                if dataset.step == "system_adhoc"
+            },
+            **{
+                key: dataset.size
+                for key, dataset in self.validation_dataset.items()
+                if dataset.step == "system_adhoc"
+            },
         }
-        self.control_file["used_datasets"]["training"] = {key: dataset.to_dict() for key, dataset in self.training_dataset.items()}
-        self.control_file["used_datasets"]["validation"] = {key: dataset.to_dict() for key, dataset in self.validation_dataset.items()}
+        self.control_file["used_datasets"]["training"] = {
+            key: dataset.to_dict() for key, dataset in self.training_dataset.items()
+        }
+        self.control_file["used_datasets"]["validation"] = {
+            key: dataset.to_dict() for key, dataset in self.validation_dataset.items()
+        }
 
         self.save_control_file()
 
     def save_control_file(self):
-        self.control_file = {key: self.control_file[key] for key in sorted(self.control_file.keys())}
-        self.control_file["system_datasets"] = {key: self.control_file["system_datasets"][key] for key in sorted(self.control_file["system_datasets"].keys())}
+        self.control_file = {
+            key: self.control_file[key] for key in sorted(self.control_file.keys())
+        }
+        self.control_file["system_datasets"] = {
+            key: self.control_file["system_datasets"][key]
+            for key in sorted(self.control_file["system_datasets"].keys())
+        }
         write_json_file(
             json_dict=self.control_file,
             file_path=self.dataset_dir.parent / "control" / "dataset.json",
         )
+
+    def convert_dataset(self, to_extxyz: bool = False, to_set000: bool = False):
+        """Convert the data ensembles of the dataset from extxyz to set.000 format or vice versa"""
+        if to_extxyz and self.data_format == "set.000":
+            for dataset in self.training_dataset.values():
+                dataset.to_extxyz(save=True)
+            for dataset in self.validation_dataset.values():
+                dataset.to_extxyz(save=True)
+        elif to_set000 and self.data_format == "extxyz":
+            for dataset in self.training_dataset.values():
+                dataset.to_set000()
+            for dataset in self.validation_dataset.values():
+                dataset.to_set000()
+        else:
+            raise ValueError(
+                "The provided conversion is not valid. Please use to_extxyz=True or to_set000=True."
+            )
+
+    def prepare_for_mace_train(self, data_path: Path):
+        """Data should be converted into the extxyz format and put together in a single file"""
+        combined_frames = []
+        for dataset in self.training_dataset.values():
+            dataset_frames = dataset.to_extxyz(save=False)
+            arcann_logger.debug(
+                f"Loading dataset {dataset.path} for MACE training preparation: {len(dataset_frames)} frames"
+            )
+            combined_frames.extend(dataset_frames)
+        arcann_logger.debug(
+            f"Number of frames in the combined training dataset: {len(combined_frames)}"
+        )
+        with (data_path / "training_dataset.extxyz").open("w+") as f:
+            write_extxyz(f, combined_frames)
+
+        valid_frames, test_frames = [], []
+        for dataset in self.validation_dataset.values():
+            dataset_frames = dataset.to_extxyz(save=False)
+            arcann_logger.debug(
+                f"Loading dataset {dataset.path} for MACE validation/test preparation: {len(dataset_frames)} frames"
+            )
+            valid_frames.extend(dataset_frames[: len(dataset_frames) // 2])
+            test_frames.extend(dataset_frames[len(dataset_frames) // 2 :])
+            arcann_logger.debug(
+                f"Number of frames in the combined validation dataset: {len(valid_frames)}"
+            )
+            arcann_logger.debug(
+                f"Number of frames in the combined test dataset: {len(test_frames)}"
+            )
+        with (data_path / "validation_dataset.extxyz").open("w+") as f:
+            write_extxyz(f, valid_frames)
+        with (data_path / "test_dataset.extxyz").open("w+") as f:
+            write_extxyz(f, test_frames)
+
+    def prepare_for_deepmd_train(self):
+        pass

--- a/arcann_training/training/check.py
+++ b/arcann_training/training/check.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 # Non-standard imports
 import numpy as np
+from packaging import version
 
 # Local imports
 from arcann_training.common.check import validate_step_folder
@@ -26,6 +27,7 @@ from arcann_training.common.json import (
     write_json_file,
 )
 from arcann_training.common.list import textfile_to_string_list
+from arcann_training.common.yaml import load_yaml_file
 
 
 def main(
@@ -62,6 +64,9 @@ def main(
     control_path = training_path / "control"
     main_json = load_json_file((control_path / "config.json"))
     training_json = load_json_file((control_path / f"training_{padded_curr_iter}.json"))
+    nnp_program: str = main_json["nnp_program"]
+
+    arcann_logger.info(f"Using {nnp_program} as NNP software")
 
     # Check if we can continue
     if not training_json["is_launched"]:
@@ -77,8 +82,21 @@ def main(
     completed_count = 0
     min_nbor_dist = None
     max_nbor_size = None
-    training_input_json = None
-    deepmd_version = training_json["deepmd_model_version"]
+    if nnp_program == "deepmd":
+        nnp_version = version.parse(training_json["deepmd_model_version"])
+        training_input = (
+            load_json_file(current_path / "1" / "training.json")
+            if (current_path / "1" / "training.json").is_file()
+            else None
+        )
+
+    elif nnp_program == "mace":
+        nnp_version = version.parse(training_json["mace_model_version"])
+        training_input = (
+            load_yaml_file(current_path / "1" / "training.yaml")
+            if (current_path / "1" / "training.yaml").is_file()
+            else None
+        )
 
     for nnp in range(1, main_json["nnp_count"] + 1):
         local_path = current_path / f"{nnp}"
@@ -90,8 +108,10 @@ def main(
             training_out = []
         if training_out:
             # Finished correctly
-            if any("finished training" in s for s in training_out):
-                if deepmd_version == 3.0:
+            if nnp_program == "deepmd" and any(
+                "finished training" in s for s in training_out
+            ):
+                if nnp_program == "deepmd" and nnp_version >= version.parse("3.0.0"):
                     training_out_time = [s for s in training_out if "wall time" in s]
                     batch_pattern = r"batch\s*(\d+)\b"
                     time_pattern = r"wall time = (\d+\.\d+) s"
@@ -120,9 +140,6 @@ def main(
                                     int(n) for n in max_nbor_size_match.group(1).split()
                                 ]
 
-                if training_input_json is None:
-                    training_input_json = load_json_file(local_path / "training.json")
-
                 batch_numbers = []
 
                 for entry in training_out_time:
@@ -136,7 +153,14 @@ def main(
                         batch_numbers.append(batch_number)
                         training_times.append(training_time)
 
-                del entry, batch_match, time_match, batch_number, training_time
+                del (
+                    entry,
+                    batch_match,
+                    time_match,
+                    batch_number,
+                    training_time,
+                    training_out_time,
+                )
                 del time_pattern, batch_pattern
 
                 for suffix in ["index", "meta", "data-00000-of-00001"]:
@@ -151,9 +175,14 @@ def main(
                 step_sizes.extend(np.diff(batch_numbers))
                 del batch_numbers
                 completed_count += 1
+
+            elif nnp_program == "mace" and any(
+                "Training complete" in s for s in training_out
+            ):
+                completed_count += 1
             else:
                 arcann_logger.critical(f"DP Train - '{nnp}' not finished/failed.")
-            del training_out, training_out_time
+            del training_out
         else:
             arcann_logger.critical(f"DP Train - '{nnp}' still running/no outfile.")
         del local_path
@@ -177,7 +206,7 @@ def main(
         )
         arcann_logger.info(f"Your type map was: {main_json['type_map']}")
         arcann_logger.info(f"The total is: {sum(max_nbor_size)}")
-        selection_list = find_key_in_dict(training_input_json, "sel")
+        selection_list = find_key_in_dict(training_input, "sel")
         arcann_logger.info(
             f"In the training parameters, the expected maximum number of type-i neighbors of an atom was: {selection_list[0]} (keyword 'sel')."
         )

--- a/arcann_training/training/check.py
+++ b/arcann_training/training/check.py
@@ -11,21 +11,21 @@ Last modified: 2024/07/14
 
 # Standard library modules
 import logging
+import re
 import sys
 from pathlib import Path
-import re
 
 # Non-standard imports
 import numpy as np
 
 # Local imports
 from arcann_training.common.check import validate_step_folder
-from arcann_training.common.list import textfile_to_string_list
 from arcann_training.common.json import (
+    find_key_in_dict,
     load_json_file,
     write_json_file,
-    find_key_in_dict,
 )
+from arcann_training.common.list import textfile_to_string_list
 
 
 def main(
@@ -39,7 +39,7 @@ def main(
     arcann_logger = logging.getLogger("ArcaNN")
 
     # Get the current path and set the training path as the parent of the current path
-    current_path = Path(".").resolve()
+    current_path = Path().resolve()
     training_path = current_path.parent
 
     # Log the step and phase of the program
@@ -49,7 +49,7 @@ def main(
     arcann_logger.debug(f"Current path :{current_path}")
     arcann_logger.debug(f"Training path: {training_path}")
     arcann_logger.debug(f"Program path: {deepmd_iterative_path}")
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
 
     # Check if the current folder is correct for the current step
     validate_step_folder(current_step)
@@ -65,8 +65,8 @@ def main(
 
     # Check if we can continue
     if not training_json["is_launched"]:
-        arcann_logger.error(f"Lock found. Please execute 'training launch' first.")
-        arcann_logger.error(f"Aborting...")
+        arcann_logger.error("Lock found. Please execute 'training launch' first.")
+        arcann_logger.error("Aborting...")
         return 1
 
     # Check the normal termination of the training phase
@@ -91,14 +91,15 @@ def main(
         if training_out:
             # Finished correctly
             if any("finished training" in s for s in training_out):
-
                 if deepmd_version == 3.0:
                     training_out_time = [s for s in training_out if "wall time" in s]
                     batch_pattern = r"batch\s*(\d+)\b"
                     time_pattern = r"wall time = (\d+\.\d+) s"
-                
-                else: 
-                    training_out_time = [s for s in training_out if "training time" in s]
+
+                else:
+                    training_out_time = [
+                        s for s in training_out if "training time" in s
+                    ]
                     batch_pattern = r"batch\s*(\d+)\s"
                     time_pattern = r"training time (\d+\.\d+) s"
 
@@ -165,9 +166,9 @@ def main(
         arcann_logger.info(f"Your minimum neighbor distance is: {min_nbor_dist:.3f}")
         if min_nbor_dist < 0.1:
             arcann_logger.warning(
-                f"Your minimum neighbor distance is lower than 0.1 Angstrom."
+                "Your minimum neighbor distance is lower than 0.1 Angstrom."
             )
-            arcann_logger.warning(f"You might have a funky system.")
+            arcann_logger.warning("You might have a funky system.")
 
     if max_nbor_size is not None:
         training_json["max_nbor_size"] = max_nbor_size
@@ -182,18 +183,18 @@ def main(
         )
         if sum(max_nbor_size) > sum(selection_list[0]):
             arcann_logger.warning(
-                f"The maximum number of type-i neighbors of an atom is higher than the expected maximum number of type-i neighbors of an atom (keyword 'sel')."
+                "The maximum number of type-i neighbors of an atom is higher than the expected maximum number of type-i neighbors of an atom (keyword 'sel')."
             )
-            arcann_logger.warning(f"Please correct this.")
+            arcann_logger.warning("Please correct this.")
         if sum(selection_list[0]) > 2.0 * sum(max_nbor_size):
             arcann_logger.warning(
-                f"The expected maximum number of type-i neighbors of an atom is at least 100% larger that the ones present in the training datasets."
+                "The expected maximum number of type-i neighbors of an atom is at least 100% larger that the ones present in the training datasets."
             )
             arcann_logger.warning(
-                f"You may want to decrease the expected maximum number of type-i neighbors of an atom (keyword 'sel')."
+                "You may want to decrease the expected maximum number of type-i neighbors of an atom (keyword 'sel')."
             )
 
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
     # Update the boolean in the training JSON
     if completed_count == main_json["nnp_count"]:
         training_json["is_checked"] = True
@@ -229,7 +230,7 @@ def main(
     )
 
     # End
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
     if completed_count == main_json["nnp_count"]:
         arcann_logger.info(
             f"Step: {current_step.capitalize()} - Phase: {current_phase.capitalize()} is a success!"
@@ -238,9 +239,9 @@ def main(
         arcann_logger.critical(
             f"Step: {current_step.capitalize()} - Phase: {current_phase.capitalize()} is a failure!"
         )
-        arcann_logger.critical(f"Some DP Train did not finished correctly.")
-        arcann_logger.critical(f"Please check manually before re-exectuing this step.")
-        arcann_logger.critical(f"Aborting...")
+        arcann_logger.critical("Some DP Train did not finished correctly.")
+        arcann_logger.critical("Please check manually before re-exectuing this step.")
+        arcann_logger.critical("Aborting...")
         return 1
     del completed_count
 
@@ -250,7 +251,7 @@ def main(
     del main_json, training_json
     del curr_iter, padded_curr_iter
 
-    arcann_logger.debug(f"LOCAL")
+    arcann_logger.debug("LOCAL")
     arcann_logger.debug(f"{locals()}")
     return 0
 

--- a/arcann_training/training/check_compress.py
+++ b/arcann_training/training/check_compress.py
@@ -30,7 +30,7 @@ def main(
     arcann_logger = logging.getLogger("ArcaNN")
 
     # Get the current path and set the training path as the parent of the current path
-    current_path = Path(".").resolve()
+    current_path = Path().resolve()
     training_path = current_path.parent
 
     # Log the step and phase of the program
@@ -40,7 +40,7 @@ def main(
     arcann_logger.debug(f"Current path :{current_path}")
     arcann_logger.debug(f"Training path: {training_path}")
     arcann_logger.debug(f"Program path: {deepmd_iterative_path}")
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
 
     # Check if the current folder is correct for the current step
     validate_step_folder(current_step)
@@ -56,8 +56,8 @@ def main(
 
     # Check if we can continue
     if not training_json["is_compress_launched"]:
-        arcann_logger.error(f"Lock found. Please execute 'training compress' first.")
-        arcann_logger.error(f"Aborting...")
+        arcann_logger.error("Lock found. Please execute 'training compress' first.")
+        arcann_logger.error("Aborting...")
         return 1
 
     completed_count = 0
@@ -71,7 +71,7 @@ def main(
     del nnp
     arcann_logger.debug(f"completed_count: {completed_count}")
 
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
     # Update the boolean in the training JSON
     if completed_count == main_json["nnp_count"]:
         training_json["is_compressed"] = True
@@ -84,7 +84,7 @@ def main(
     )
 
     # End
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
     if completed_count == main_json["nnp_count"]:
         arcann_logger.info(
             f"Step: {current_step.capitalize()} - Phase: {current_phase.capitalize()} is a success!"
@@ -93,9 +93,9 @@ def main(
         arcann_logger.error(
             f"Step: {current_step.capitalize()} - Phase: {current_phase.capitalize()} is a failure!"
         )
-        arcann_logger.error(f"Some DP Compress did not finished correctly.")
-        arcann_logger.error(f"Please check manually before relaunching this step.")
-        arcann_logger.error(f"Aborting...")
+        arcann_logger.error("Some DP Compress did not finished correctly.")
+        arcann_logger.error("Please check manually before relaunching this step.")
+        arcann_logger.error("Aborting...")
     del completed_count
 
     # Cleaning
@@ -104,8 +104,8 @@ def main(
     del main_json, training_json
     del curr_iter, padded_curr_iter
 
-    arcann_logger.debug(f"LOCAL")
-    arcann_logger.debug(f"{locals()}")
+    arcann_logger.debug("LOCAL")
+    arcann_logger.debug("{locals()}")
     return 0
 
 

--- a/arcann_training/training/check_compress.py
+++ b/arcann_training/training/check_compress.py
@@ -53,6 +53,9 @@ def main(
     control_path = training_path / "control"
     main_json = load_json_file((control_path / "config.json"))
     training_json = load_json_file((control_path / f"training_{padded_curr_iter}.json"))
+    nnp_program: str = main_json["nnp_program"]
+
+    arcann_logger.info(f"Using {nnp_program} as NNP software")
 
     # Check if we can continue
     if not training_json["is_compress_launched"]:
@@ -60,20 +63,22 @@ def main(
         arcann_logger.error("Aborting...")
         return 1
 
-    completed_count = 0
-    for nnp in range(1, main_json["nnp_count"] + 1):
-        local_path = current_path / f"{nnp}"
-        if (local_path / f"graph_{nnp}_{padded_curr_iter}_compressed.pb").is_file():
-            completed_count += 1
-        else:
-            arcann_logger.critical(f"DP Compress - '{nnp}' not finished/failed.")
-        del local_path
-    del nnp
+    completed_count = None
+    if nnp_program == "deepmd":
+        completed_count = 0
+        for nnp in range(1, main_json["nnp_count"] + 1):
+            local_path = current_path / f"{nnp}"
+            if (local_path / f"graph_{nnp}_{padded_curr_iter}_compressed.pb").is_file():
+                completed_count += 1
+            else:
+                arcann_logger.critical(f"DP Compress - '{nnp}' not finished/failed.")
+            del local_path
+        del nnp
     arcann_logger.debug(f"completed_count: {completed_count}")
 
     arcann_logger.info("-" * 88)
     # Update the boolean in the training JSON
-    if completed_count == main_json["nnp_count"]:
+    if completed_count == main_json["nnp_count"] or nnp_program == "mace":
         training_json["is_compressed"] = True
 
     # Dump the JSON files (training)
@@ -85,7 +90,7 @@ def main(
 
     # End
     arcann_logger.info("-" * 88)
-    if completed_count == main_json["nnp_count"]:
+    if completed_count == main_json["nnp_count"] or nnp_program == "mace":
         arcann_logger.info(
             f"Step: {current_step.capitalize()} - Phase: {current_phase.capitalize()} is a success!"
         )

--- a/arcann_training/training/check_freeze.py
+++ b/arcann_training/training/check_freeze.py
@@ -30,7 +30,7 @@ def main(
     arcann_logger = logging.getLogger("ArcaNN")
 
     # Get the current path and set the training path as the parent of the current path
-    current_path = Path(".").resolve()
+    current_path = Path().resolve()
     training_path = current_path.parent
 
     # Log the step and phase of the program
@@ -40,7 +40,7 @@ def main(
     arcann_logger.debug(f"Current path :{current_path}")
     arcann_logger.debug(f"Training path: {training_path}")
     arcann_logger.debug(f"Program path: {deepmd_iterative_path}")
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
 
     # Check if the current folder is correct for the current step
     validate_step_folder(current_step)
@@ -56,8 +56,8 @@ def main(
 
     # Check if we can continue
     if not training_json["is_freeze_launched"]:
-        arcann_logger.error(f"Lock found. Please execute 'training freeze' first.")
-        arcann_logger.error(f"Aborting...")
+        arcann_logger.error("Lock found. Please execute 'training freeze' first.")
+        arcann_logger.error("Aborting...")
         return 1
 
     completed_count = 0
@@ -71,7 +71,7 @@ def main(
     del nnp
     arcann_logger.debug(f"completed_count: {completed_count}")
 
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
     # Update the boolean in the training JSON
     if completed_count == main_json["nnp_count"]:
         training_json["is_frozen"] = True
@@ -84,7 +84,7 @@ def main(
     )
 
     # End
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
     if completed_count == main_json["nnp_count"]:
         arcann_logger.info(
             f"Step: {current_step.capitalize()} - Phase: {current_phase.capitalize()} is a success!"
@@ -93,9 +93,9 @@ def main(
         arcann_logger.error(
             f"Step: {current_step.capitalize()} - Phase: {current_phase.capitalize()} is a failure!"
         )
-        arcann_logger.error(f"Some DP Freeze did not finished correctly.")
-        arcann_logger.error(f"Please check manually before relaunching this step.")
-        arcann_logger.error(f"Aborting...")
+        arcann_logger.error("Some DP Freeze did not finished correctly.")
+        arcann_logger.error("Please check manually before relaunching this step.")
+        arcann_logger.error("Aborting...")
     del completed_count
 
     # Cleaning
@@ -104,7 +104,7 @@ def main(
     del main_json, training_json
     del curr_iter, padded_curr_iter
 
-    arcann_logger.debug(f"LOCAL")
+    arcann_logger.debug("LOCAL")
     arcann_logger.debug(f"{locals()}")
     return 0
 

--- a/arcann_training/training/check_freeze.py
+++ b/arcann_training/training/check_freeze.py
@@ -53,6 +53,9 @@ def main(
     control_path = training_path / "control"
     main_json = load_json_file((control_path / "config.json"))
     training_json = load_json_file((control_path / f"training_{padded_curr_iter}.json"))
+    nnp_program: str = main_json["nnp_program"]
+
+    arcann_logger.info(f"Using {nnp_program} as NNP software")
 
     # Check if we can continue
     if not training_json["is_freeze_launched"]:
@@ -60,20 +63,22 @@ def main(
         arcann_logger.error("Aborting...")
         return 1
 
-    completed_count = 0
-    for nnp in range(1, main_json["nnp_count"] + 1):
-        local_path = current_path / f"{nnp}"
-        if (local_path / f"graph_{nnp}_{padded_curr_iter}.pb").is_file():
-            completed_count += 1
-        else:
-            arcann_logger.critical(f"DP Freeze - '{nnp}' not finished/failed.")
-        del local_path
-    del nnp
-    arcann_logger.debug(f"completed_count: {completed_count}")
+    completed_count = None
+    if nnp_program == "deepmd":
+        completed_count = 0
+        for nnp in range(1, main_json["nnp_count"] + 1):
+            local_path = current_path / f"{nnp}"
+            if (local_path / f"graph_{nnp}_{padded_curr_iter}.pb").is_file():
+                completed_count += 1
+            else:
+                arcann_logger.critical(f"DP Freeze - '{nnp}' not finished/failed.")
+            del local_path
+        del nnp
+        arcann_logger.debug(f"completed_count: {completed_count}")
 
     arcann_logger.info("-" * 88)
     # Update the boolean in the training JSON
-    if completed_count == main_json["nnp_count"]:
+    if completed_count == main_json["nnp_count"] or nnp_program == "mace":
         training_json["is_frozen"] = True
 
     # Dump the JSON (training JSON)
@@ -85,7 +90,7 @@ def main(
 
     # End
     arcann_logger.info("-" * 88)
-    if completed_count == main_json["nnp_count"]:
+    if completed_count == main_json["nnp_count"] or nnp_program == "mace":
         arcann_logger.info(
             f"Step: {current_step.capitalize()} - Phase: {current_phase.capitalize()} is a success!"
         )

--- a/arcann_training/training/clean.py
+++ b/arcann_training/training/clean.py
@@ -60,6 +60,9 @@ def main(
     training_config = load_json_file(
         (control_path / f"training_{padded_curr_iter}.json")
     )
+    nnp_program: str = main_json["nnp_program"]
+
+    arcann_logger.info(f"Using {nnp_program} as NNP software")
 
     # Check if we can continue
     if not training_config["is_incremented"]:

--- a/arcann_training/training/clean.py
+++ b/arcann_training/training/clean.py
@@ -17,9 +17,9 @@ from pathlib import Path
 # Local imports
 from arcann_training.common.check import validate_step_folder
 from arcann_training.common.filesystem import (
+    remove_all_symlink,
     remove_files_matching_glob,
     remove_tree,
-    remove_all_symlink,
 )
 from arcann_training.common.json import load_json_file
 
@@ -35,7 +35,7 @@ def main(
     arcann_logger = logging.getLogger("ArcaNN")
 
     # Get the current path and set the training path as the parent of the current path
-    current_path = Path(".").resolve()
+    current_path = Path().resolve()
     training_path = current_path.parent
 
     # Log the step and phase of the program
@@ -45,7 +45,7 @@ def main(
     arcann_logger.debug(f"Current path :{current_path}")
     arcann_logger.debug(f"Training path: {training_path}")
     arcann_logger.debug(f"Program path: {deepmd_iterative_path}")
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
 
     # Check if the current folder is correct for the current step
     validate_step_folder(current_step)
@@ -63,16 +63,16 @@ def main(
 
     # Check if we can continue
     if not training_config["is_incremented"]:
-        arcann_logger.error(f"Lock found. Please execute 'training increment' first.")
-        arcann_logger.error(f"Aborting...")
+        arcann_logger.error("Lock found. Please execute 'training increment' first.")
+        arcann_logger.error("Aborting...")
         return 1
-    arcann_logger.critical(f"This is the cleaning step for training step.")
-    arcann_logger.critical(f"It should be run after training increment phase.")
-    arcann_logger.critical(f"This is will delete:")
+    arcann_logger.critical("This is the cleaning step for training step.")
+    arcann_logger.critical("It should be run after training increment phase.")
+    arcann_logger.critical("This is will delete:")
     arcann_logger.critical(
-        f"symbolic links, 'job_*.sh', 'training.out', 'graph*freeze.out', 'graph*compress.out', 'checkpoint.*', 'input_v2_compat.json', 'DeepMD_*'"
+        "symbolic links, 'job_*.sh', 'training.out', 'graph*freeze.out', 'graph*compress.out', 'checkpoint.*', 'input_v2_compat.json', 'DeepMD_*'"
     )
-    arcann_logger.critical(f"'model-compression' folders")
+    arcann_logger.critical("'model-compression' folders")
     arcann_logger.critical(
         f"'*.pb' models files (they are saved in the '{current_path.parent / 'NNP'}' root folder)"
     )
@@ -81,12 +81,12 @@ def main(
     )
     arcann_logger.critical(f"in the folder: '{current_path}' and all subdirectories.")
     continuing = input(
-        f"Do you want to continue? [Enter 'Y' for yes, or any other key to abort]: "
+        "Do you want to continue? [Enter 'Y' for yes, or any other key to abort]: "
     )
     if continuing == "Y":
         del continuing
     else:
-        arcann_logger.error(f"Aborting...")
+        arcann_logger.error("Aborting...")
         return 0
 
     # Delete
@@ -94,22 +94,22 @@ def main(
     remove_all_symlink(current_path)
     arcann_logger.info("Deleting job files...")
     remove_files_matching_glob(current_path, "**/job_*.sh")
-    arcann_logger.info(f"Deleting training unwanted output file..")
+    arcann_logger.info("Deleting training unwanted output file..")
     remove_files_matching_glob(current_path, "**/training.out")
-    arcann_logger.info(f"Deleting freezing unwanted output files...")
+    arcann_logger.info("Deleting freezing unwanted output files...")
     remove_files_matching_glob(current_path, "**/graph*freeze.out")
-    arcann_logger.info(f"Deleting compressing unwanted output file...")
+    arcann_logger.info("Deleting compressing unwanted output file...")
     remove_files_matching_glob(current_path, "**/graph*compress.out")
-    arcann_logger.info(f"Deleting extra model.ckpt...")
+    arcann_logger.info("Deleting extra model.ckpt...")
     remove_files_matching_glob(current_path, "**/model.ckpt-*")
-    arcann_logger.info(f"Deleting models files files...")
+    arcann_logger.info("Deleting models files files...")
     remove_files_matching_glob(current_path, "**/*.pb")
-    arcann_logger.info(f"Deleting extra training files...")
+    arcann_logger.info("Deleting extra training files...")
     remove_files_matching_glob(current_path, "**/checkpoint")
     remove_files_matching_glob(current_path, "**/input_v2_compat.json")
-    arcann_logger.info(f"Deleting job error files...")
+    arcann_logger.info("Deleting job error files...")
     remove_files_matching_glob(current_path, "**/DeepMD_*")
-    arcann_logger.info(f"Deleting the data folder ...")
+    arcann_logger.info("Deleting the data folder ...")
     if (current_path / "data").is_dir():
         remove_tree(current_path / "data")
     for nnp in range(1, main_json["nnp_count"] + 1):
@@ -117,7 +117,7 @@ def main(
         if (local_path / "model-compression").is_dir():
             arcann_logger.info("Deleting the temp model-compression folder...")
             remove_tree(local_path / "model-compression")
-    arcann_logger.info(f"Cleaning done!")
+    arcann_logger.info("Cleaning done!")
 
     # End
     arcann_logger.info(
@@ -130,7 +130,7 @@ def main(
     del main_json, training_config
     del curr_iter, padded_curr_iter
 
-    arcann_logger.debug(f"LOCAL")
+    arcann_logger.debug("LOCAL")
     arcann_logger.debug(f"{locals()}")
     return 0
 

--- a/arcann_training/training/compress.py
+++ b/arcann_training/training/compress.py
@@ -11,18 +11,18 @@ Last modified: 2024/05/15
 
 # Standard library modules
 import logging
+import subprocess
 import sys
 from pathlib import Path
-import subprocess
 
 # Local imports
 from arcann_training.common.check import validate_step_folder
 from arcann_training.common.filesystem import change_directory, check_file_existence
 from arcann_training.common.json import (
+    backup_and_overwrite_json_file,
+    load_default_json_file,
     load_json_file,
     write_json_file,
-    load_default_json_file,
-    backup_and_overwrite_json_file,
 )
 from arcann_training.common.list import (
     replace_substring_in_string_list,
@@ -47,7 +47,7 @@ def main(
     arcann_logger = logging.getLogger("ArcaNN")
 
     # Get the current path and set the training path as the parent of the current path
-    current_path = Path(".").resolve()
+    current_path = Path().resolve()
     training_path = current_path.parent
 
     # Log the step and phase of the program
@@ -57,7 +57,7 @@ def main(
     arcann_logger.debug(f"Current path :{current_path}")
     arcann_logger.debug(f"Training path: {training_path}")
     arcann_logger.debug(f"Program path: {deepmd_iterative_path}")
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
 
     # Check if the current folder is correct for the current step
     validate_step_folder(current_step)
@@ -87,9 +87,9 @@ def main(
     if (current_path / "used_input.json").is_file():
         current_input_json = load_json_file((current_path / "used_input.json"))
     else:
-        arcann_logger.warning(f"No used_input.json found. Starting with empty one.")
+        arcann_logger.warning("No used_input.json found. Starting with empty one.")
         arcann_logger.warning(
-            f"You should avoid this by not deleting the used_input.json file."
+            "You should avoid this by not deleting the used_input.json file."
         )
         current_input_json = {}
     arcann_logger.debug(f"current_input_json: {current_input_json}")
@@ -120,20 +120,18 @@ def main(
 
     # Check if we can continue
     if training_json["is_compress_launched"]:
-        arcann_logger.critical(f"Already launched...")
+        arcann_logger.critical("Already launched...")
         continuing = input(
-            f"Do you want to continue?\n['Y' for yes, anything else to abort]\n"
+            "Do you want to continue?\n['Y' for yes, anything else to abort]\n"
         )
         if continuing == "Y":
             del continuing
         else:
-            arcann_logger.error(f"Aborting...")
+            arcann_logger.error("Aborting...")
             return 0
     if not training_json["is_frozen"]:
-        arcann_logger.error(
-            f"Lock found. Please execute 'training check_freeze' first."
-        )
-        arcann_logger.error(f"Aborting...")
+        arcann_logger.error("Lock found. Please execute 'training check_freeze' first.")
+        arcann_logger.error("Aborting...")
         return 1
 
     # Get the machine keyword (Priority: user > previous > default)
@@ -195,7 +193,7 @@ def main(
         arcann_logger.error(
             f"No JOB file provided for '{current_step.capitalize()} / {current_phase.capitalize()}' for this machine."
         )
-        arcann_logger.error(f"Aborting...")
+        arcann_logger.error("Aborting...")
         return 1
 
     arcann_logger.debug(
@@ -258,7 +256,7 @@ def main(
         ).is_file():
             change_directory(local_path)
             try:
-                subprocess.run(
+                subprocess.run(  # noqa: S603
                     [
                         machine_launch_command,
                         f"./job_deepmd_compress_{machine_spec['arch_type']}_{machine}.sh",
@@ -277,7 +275,7 @@ def main(
 
     del nnp, master_job_file
 
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
     # Update the boolean in the training JSON
     if completed_count == main_json["nnp_count"]:
         training_json["is_compress_launched"] = True
@@ -294,7 +292,7 @@ def main(
     )
 
     # End
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
     if completed_count == main_json["nnp_count"]:
         arcann_logger.info(
             f"Step: {current_step.capitalize()} - Phase: {current_phase.capitalize()} is a success!"
@@ -303,9 +301,9 @@ def main(
         arcann_logger.critical(
             f"Step: {current_step.capitalize()} - Phase: {current_phase.capitalize()} is semi-success!"
         )
-        arcann_logger.critical(f"Some jobs did not launch correctly.")
+        arcann_logger.critical("Some jobs did not launch correctly.")
         arcann_logger.critical(
-            f"Please launch manually before continuing to the next step."
+            "Please launch manually before continuing to the next step."
         )
     del completed_count
 
@@ -329,7 +327,7 @@ def main(
         machine_job_scheduler,
     )
 
-    arcann_logger.debug(f"LOCAL")
+    arcann_logger.debug("LOCAL")
     arcann_logger.debug(f"{locals()}")
     return 0
 

--- a/arcann_training/training/compress.py
+++ b/arcann_training/training/compress.py
@@ -98,6 +98,9 @@ def main(
     control_path = training_path / "control"
     main_json = load_json_file((control_path / "config.json"))
     training_json = load_json_file((control_path / f"training_{padded_curr_iter}.json"))
+    nnp_program: str = main_json["nnp_program"]
+
+    arcann_logger.info(f"Using {nnp_program} as NNP software")
 
     # Load the previous training JSON
     if curr_iter > 0:
@@ -184,100 +187,107 @@ def main(
     training_json["user_machine_keyword_compress"] = user_machine_keyword
 
     # Check if the job file exists
-    job_file_name = f"job_deepmd_compress_{machine_spec['arch_type']}_{machine}.sh"
-    if (current_path.parent / "user_files" / job_file_name).is_file():
-        master_job_file = textfile_to_string_list(
-            current_path.parent / "user_files" / job_file_name
-        )
-    else:
-        arcann_logger.error(
-            f"No JOB file provided for '{current_step.capitalize()} / {current_phase.capitalize()}' for this machine."
-        )
-        arcann_logger.error("Aborting...")
-        return 1
-
-    arcann_logger.debug(
-        f"master_job_file: {master_job_file[0:5]}, {master_job_file[-5:-1]}"
-    )
-    del job_file_name
-
-    # Prep and launch DP Compress
-    completed_count = 0
-    walltime_approx_s = 3900
-    for nnp in range(1, main_json["nnp_count"] + 1):
-        local_path = current_path / f"{nnp}"
-
-        check_file_existence(local_path / "model.ckpt.index")
-
-        job_file = replace_in_slurm_file_general(
-            master_job_file,
-            machine_spec,
-            walltime_approx_s,
-            machine_walltime_format,
-            current_input_json["job_email"],
-        )
-        # Replace the inputs/variables in the job file
-        job_file = replace_substring_in_string_list(
-            job_file, "_R_DEEPMD_VERSION_", f"{training_json['deepmd_model_version']}"
-        )
-        job_file = replace_substring_in_string_list(
-            job_file, "_R_DEEPMD_MODEL_FILE_", f"graph_{nnp}_{padded_curr_iter}.pb"
-        )
-        job_file = replace_substring_in_string_list(
-            job_file,
-            "_R_DEEPMD_COMPRESSED_MODEL_FILE_",
-            f"graph_{nnp}_{padded_curr_iter}_compressed.pb",
-        )
-        job_file = replace_substring_in_string_list(
-            job_file,
-            "_R_DEEPMD_LOG_FILE_",
-            f"graph_{nnp}_{padded_curr_iter}_compress.log",
-        )
-        job_file = replace_substring_in_string_list(
-            job_file,
-            "_R_DEEPMD_OUTPUT_FILE_",
-            f"graph_{nnp}_{padded_curr_iter}_compress.out",
-        )
-
-        string_list_to_textfile(
-            local_path
-            / f"job_deepmd_compress_{machine_spec['arch_type']}_{machine}.sh",
-            job_file,
-            read_only=True,
-        )
-        del job_file
-
-        with (local_path / "checkpoint").open("w") as f:
-            f.write('model_checkpoint_path: "model.ckpt"\n')
-            f.write('all_model_checkpoint_paths: "model.ckpt"\n')
-        del f
-        if (
-            local_path / f"job_deepmd_compress_{machine_spec['arch_type']}_{machine}.sh"
-        ).is_file():
-            change_directory(local_path)
-            try:
-                subprocess.run(  # noqa: S603
-                    [
-                        machine_launch_command,
-                        f"./job_deepmd_compress_{machine_spec['arch_type']}_{machine}.sh",
-                    ]
-                )
-                arcann_logger.info(f"DP Compress - '{nnp}' launched.")
-                completed_count += 1
-            except FileNotFoundError:
-                arcann_logger.critical(
-                    f"DP Compress - '{nnp}' NOT launched - '{machine_launch_command}' not found."
-                )
-            change_directory(local_path.parent)
+    completed_count = None
+    if nnp_program == "deepmd":
+        job_file_name = f"job_deepmd_compress_{machine_spec['arch_type']}_{machine}.sh"
+        if (current_path.parent / "user_files" / job_file_name).is_file():
+            master_job_file = textfile_to_string_list(
+                current_path.parent / "user_files" / job_file_name
+            )
         else:
-            arcann_logger.critical(f"DP Compress - '{nnp}' NOT launched - No job file.")
-        del local_path
+            arcann_logger.error(
+                f"No JOB file provided for '{current_step.capitalize()} / {current_phase.capitalize()}' for this machine."
+            )
+            arcann_logger.error("Aborting...")
+            return 1
 
-    del nnp, master_job_file
+        arcann_logger.debug(
+            f"master_job_file: {master_job_file[0:5]}, {master_job_file[-5:-1]}"
+        )
+        del job_file_name
+
+        # Prep and launch DP Compress
+        completed_count = 0
+        walltime_approx_s = 3900
+        for nnp in range(1, main_json["nnp_count"] + 1):
+            local_path = current_path / f"{nnp}"
+
+            check_file_existence(local_path / "model.ckpt.index")
+
+            job_file = replace_in_slurm_file_general(
+                master_job_file,
+                machine_spec,
+                walltime_approx_s,
+                machine_walltime_format,
+                current_input_json["job_email"],
+            )
+            # Replace the inputs/variables in the job file
+            job_file = replace_substring_in_string_list(
+                job_file,
+                "_R_DEEPMD_VERSION_",
+                f"{training_json['deepmd_model_version']}",
+            )
+            job_file = replace_substring_in_string_list(
+                job_file, "_R_DEEPMD_MODEL_FILE_", f"graph_{nnp}_{padded_curr_iter}.pb"
+            )
+            job_file = replace_substring_in_string_list(
+                job_file,
+                "_R_DEEPMD_COMPRESSED_MODEL_FILE_",
+                f"graph_{nnp}_{padded_curr_iter}_compressed.pb",
+            )
+            job_file = replace_substring_in_string_list(
+                job_file,
+                "_R_DEEPMD_LOG_FILE_",
+                f"graph_{nnp}_{padded_curr_iter}_compress.log",
+            )
+            job_file = replace_substring_in_string_list(
+                job_file,
+                "_R_DEEPMD_OUTPUT_FILE_",
+                f"graph_{nnp}_{padded_curr_iter}_compress.out",
+            )
+
+            string_list_to_textfile(
+                local_path
+                / f"job_deepmd_compress_{machine_spec['arch_type']}_{machine}.sh",
+                job_file,
+                read_only=True,
+            )
+            del job_file
+
+            with (local_path / "checkpoint").open("w") as f:
+                f.write('model_checkpoint_path: "model.ckpt"\n')
+                f.write('all_model_checkpoint_paths: "model.ckpt"\n')
+            del f
+            if (
+                local_path
+                / f"job_deepmd_compress_{machine_spec['arch_type']}_{machine}.sh"
+            ).is_file():
+                change_directory(local_path)
+                try:
+                    subprocess.run(  # noqa: S603
+                        [
+                            machine_launch_command,
+                            f"./job_deepmd_compress_{machine_spec['arch_type']}_{machine}.sh",
+                        ]
+                    )
+                    arcann_logger.info(f"DP Compress - '{nnp}' launched.")
+                    completed_count += 1
+                except FileNotFoundError:
+                    arcann_logger.critical(
+                        f"DP Compress - '{nnp}' NOT launched - '{machine_launch_command}' not found."
+                    )
+                change_directory(local_path.parent)
+            else:
+                arcann_logger.critical(
+                    f"DP Compress - '{nnp}' NOT launched - No job file."
+                )
+            del local_path
+
+        del nnp, master_job_file, user_machine_keyword, walltime_approx_s
 
     arcann_logger.info("-" * 88)
     # Update the boolean in the training JSON
-    if completed_count == main_json["nnp_count"]:
+    if completed_count == main_json["nnp_count"] or nnp_program == "mace":
         training_json["is_compress_launched"] = True
 
     # Dump the JSON files (main, training and current input)
@@ -296,6 +306,13 @@ def main(
     if completed_count == main_json["nnp_count"]:
         arcann_logger.info(
             f"Step: {current_step.capitalize()} - Phase: {current_phase.capitalize()} is a success!"
+        )
+    elif nnp_program == "mace":
+        arcann_logger.info(
+            f"Step: {current_step.capitalize()} - Phase: {current_phase.capitalize()} is a success!"
+        )
+        arcann_logger.info(
+            "BUT BE CARREFUL, you're using a MACE model that doesn't require compression, so no job was launched."
         )
     else:
         arcann_logger.critical(
@@ -316,7 +333,6 @@ def main(
         user_input_json_present,
         user_input_json_filename,
     )
-    del user_machine_keyword, walltime_approx_s
     del main_json, current_input_json, training_json
     del curr_iter, padded_curr_iter
     del (

--- a/arcann_training/training/freeze.py
+++ b/arcann_training/training/freeze.py
@@ -11,18 +11,18 @@ Last modified: 2024/05/15
 
 # Standard library modules
 import logging
+import subprocess
 import sys
 from pathlib import Path
-import subprocess
 
 # Local imports
 from arcann_training.common.check import validate_step_folder
 from arcann_training.common.filesystem import change_directory, check_file_existence
 from arcann_training.common.json import (
+    backup_and_overwrite_json_file,
+    load_default_json_file,
     load_json_file,
     write_json_file,
-    load_default_json_file,
-    backup_and_overwrite_json_file,
 )
 from arcann_training.common.list import (
     replace_substring_in_string_list,
@@ -47,7 +47,7 @@ def main(
     arcann_logger = logging.getLogger("ArcaNN")
 
     # Get the current path and set the training path as the parent of the current path
-    current_path = Path(".").resolve()
+    current_path = Path().resolve()
     training_path = current_path.parent
 
     # Log the step and phase of the program
@@ -57,7 +57,7 @@ def main(
     arcann_logger.debug(f"Current path :{current_path}")
     arcann_logger.debug(f"Training path: {training_path}")
     arcann_logger.debug(f"Program path: {deepmd_iterative_path}")
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
 
     # Check if the current folder is correct for the current step
     validate_step_folder(current_step)
@@ -87,9 +87,9 @@ def main(
     if (current_path / "used_input.json").is_file():
         current_input_json = load_json_file((current_path / "used_input.json"))
     else:
-        arcann_logger.warning(f"No used_input.json found. Starting with empty one.")
+        arcann_logger.warning("No used_input.json found. Starting with empty one.")
         arcann_logger.warning(
-            f"You should avoid this by not deleting the used_input.json file."
+            "You should avoid this by not deleting the used_input.json file."
         )
         current_input_json = {}
     arcann_logger.debug(f"current_input_json: {current_input_json}")
@@ -120,18 +120,18 @@ def main(
 
     # Check if we can continue
     if training_json["is_freeze_launched"]:
-        arcann_logger.critical(f"Already launched...")
+        arcann_logger.critical("Already launched...")
         continuing = input(
-            f"Do you want to continue?\n['Y' for yes, anything else to abort]\n"
+            "Do you want to continue?\n['Y' for yes, anything else to abort]\n"
         )
         if continuing == "Y":
             del continuing
         else:
-            arcann_logger.error(f"Aborting...")
+            arcann_logger.error("Aborting...")
             return 0
     if not training_json["is_checked"]:
-        arcann_logger.error(f"Lock found. Please execute 'training check' first.")
-        arcann_logger.error(f"Aborting...")
+        arcann_logger.error("Lock found. Please execute 'training check' first.")
+        arcann_logger.error("Aborting...")
         return 1
 
     # Get the machine keyword (Priority: user > previous > default)
@@ -193,7 +193,7 @@ def main(
         arcann_logger.error(
             f"No JOB file provided for '{current_step.capitalize()} / {current_phase.capitalize()}' for this machine."
         )
-        arcann_logger.error(f"Aborting...")
+        arcann_logger.error("Aborting...")
         return 1
 
     arcann_logger.debug(
@@ -254,7 +254,7 @@ def main(
         ).is_file():
             change_directory(local_path)
             try:
-                subprocess.run(
+                subprocess.run(  # noqa: S603
                     [
                         machine_launch_command,
                         f"./job_deepmd_freeze_{machine_spec['arch_type']}_{machine}.sh",
@@ -273,7 +273,7 @@ def main(
 
     del nnp, master_job_file
 
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
     # Update the boolean in the training JSON
     if completed_count == main_json["nnp_count"]:
         training_json["is_freeze_launched"] = True
@@ -290,7 +290,7 @@ def main(
     )
 
     # End
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
     if completed_count == main_json["nnp_count"]:
         arcann_logger.info(
             f"Step: {current_step.capitalize()} - Phase: {current_phase.capitalize()} is a success!"
@@ -299,9 +299,9 @@ def main(
         arcann_logger.critical(
             f"Step: {current_step.capitalize()} - Phase: {current_phase.capitalize()} is semi-success!"
         )
-        arcann_logger.critical(f"Some jobs did not launch correctly.")
+        arcann_logger.critical("Some jobs did not launch correctly.")
         arcann_logger.critical(
-            f"Please launch manually before continuing to the next step."
+            "Please launch manually before continuing to the next step."
         )
     del completed_count
 
@@ -325,7 +325,7 @@ def main(
         machine_job_scheduler,
     )
 
-    arcann_logger.debug(f"LOCAL")
+    arcann_logger.debug("LOCAL")
     arcann_logger.debug(f"{locals()}")
     return 0
 

--- a/arcann_training/training/freeze.py
+++ b/arcann_training/training/freeze.py
@@ -98,6 +98,9 @@ def main(
     control_path = training_path / "control"
     main_json = load_json_file((control_path / "config.json"))
     training_json = load_json_file((control_path / f"training_{padded_curr_iter}.json"))
+    nnp_program: str = main_json["nnp_program"]
+
+    arcann_logger.info(f"Using {nnp_program} as NNP software")
 
     # Load the previous training JSON
     if curr_iter > 0:
@@ -184,98 +187,106 @@ def main(
     training_json["user_machine_keyword_freeze"] = user_machine_keyword
 
     # Check if the job file exists
-    job_file_name = f"job_deepmd_freeze_{machine_spec['arch_type']}_{machine}.sh"
-    if (current_path.parent / "user_files" / job_file_name).is_file():
-        master_job_file = textfile_to_string_list(
-            current_path.parent / "user_files" / job_file_name
-        )
-    else:
-        arcann_logger.error(
-            f"No JOB file provided for '{current_step.capitalize()} / {current_phase.capitalize()}' for this machine."
-        )
-        arcann_logger.error("Aborting...")
-        return 1
-
-    arcann_logger.debug(
-        f"master_job_file: {master_job_file[0:5]}, {master_job_file[-5:-1]}"
-    )
-    del job_file_name
-
-    # Prep and launch DP Freeze
-    completed_count = 0
-    walltime_approx_s = 3600
-    for nnp in range(1, main_json["nnp_count"] + 1):
-        local_path = current_path / f"{nnp}"
-
-        check_file_existence(local_path / "model.ckpt.index")
-
-        job_file = replace_in_slurm_file_general(
-            master_job_file,
-            machine_spec,
-            walltime_approx_s,
-            machine_walltime_format,
-            current_input_json["job_email"],
-        )
-
-        # Replace the inputs/variables in the job file
-        job_file = replace_substring_in_string_list(
-            job_file, "_R_DEEPMD_VERSION_", f"{training_json['deepmd_model_version']}"
-        )
-        job_file = replace_substring_in_string_list(
-            job_file, "_R_DEEPMD_MODEL_FILE_", f"graph_{nnp}_{padded_curr_iter}.pb"
-        )
-        job_file = replace_substring_in_string_list(
-            job_file, "_R_DEEPMD_CKPT_FILE_", "checkpoint"
-        )
-        job_file = replace_substring_in_string_list(
-            job_file,
-            "_R_DEEPMD_LOG_FILE_",
-            f"graph_{nnp}_{padded_curr_iter}_freeze.log",
-        )
-        job_file = replace_substring_in_string_list(
-            job_file,
-            "_R_DEEPMD_OUTPUT_FILE_",
-            f"graph_{nnp}_{padded_curr_iter}_freeze.out",
-        )
-
-        string_list_to_textfile(
-            local_path / f"job_deepmd_freeze_{machine_spec['arch_type']}_{machine}.sh",
-            job_file,
-            read_only=True,
-        )
-        del job_file
-
-        with (local_path / "checkpoint").open("w") as f:
-            f.write('model_checkpoint_path: "model.ckpt"\n')
-            f.write('all_model_checkpoint_paths: "model.ckpt"\n')
-        del f
-        if (
-            local_path / f"job_deepmd_freeze_{machine_spec['arch_type']}_{machine}.sh"
-        ).is_file():
-            change_directory(local_path)
-            try:
-                subprocess.run(  # noqa: S603
-                    [
-                        machine_launch_command,
-                        f"./job_deepmd_freeze_{machine_spec['arch_type']}_{machine}.sh",
-                    ]
-                )
-                arcann_logger.info(f"DP Freeze - '{nnp}' launched.")
-                completed_count += 1
-            except FileNotFoundError:
-                arcann_logger.critical(
-                    f"DP Freeze - '{nnp}' NOT launched - '{machine_launch_command}' not found."
-                )
-            change_directory(local_path.parent)
+    completed_count = None
+    if nnp_program == "deepmd":
+        job_file_name = f"job_deepmd_freeze_{machine_spec['arch_type']}_{machine}.sh"
+        if (current_path.parent / "user_files" / job_file_name).is_file():
+            master_job_file = textfile_to_string_list(
+                current_path.parent / "user_files" / job_file_name
+            )
         else:
-            arcann_logger.critical(f"DP Freeze - '{nnp}' NOT launched - No job file.")
-        del local_path
+            arcann_logger.error(
+                f"No JOB file provided for '{current_step.capitalize()} / {current_phase.capitalize()}' for this machine."
+            )
+            arcann_logger.error("Aborting...")
+            return 1
 
-    del nnp, master_job_file
+        arcann_logger.debug(
+            f"master_job_file: {master_job_file[0:5]}, {master_job_file[-5:-1]}"
+        )
+        del job_file_name
+
+        # Prep and launch DP Freeze
+        completed_count = 0
+        walltime_approx_s = 3600
+        for nnp in range(1, main_json["nnp_count"] + 1):
+            local_path = current_path / f"{nnp}"
+
+            check_file_existence(local_path / "model.ckpt.index")
+
+            job_file = replace_in_slurm_file_general(
+                master_job_file,
+                machine_spec,
+                walltime_approx_s,
+                machine_walltime_format,
+                current_input_json["job_email"],
+            )
+
+            # Replace the inputs/variables in the job file
+            job_file = replace_substring_in_string_list(
+                job_file,
+                "_R_DEEPMD_VERSION_",
+                f"{training_json['deepmd_model_version']}",
+            )
+            job_file = replace_substring_in_string_list(
+                job_file, "_R_DEEPMD_MODEL_FILE_", f"graph_{nnp}_{padded_curr_iter}.pb"
+            )
+            job_file = replace_substring_in_string_list(
+                job_file, "_R_DEEPMD_CKPT_FILE_", "checkpoint"
+            )
+            job_file = replace_substring_in_string_list(
+                job_file,
+                "_R_DEEPMD_LOG_FILE_",
+                f"graph_{nnp}_{padded_curr_iter}_freeze.log",
+            )
+            job_file = replace_substring_in_string_list(
+                job_file,
+                "_R_DEEPMD_OUTPUT_FILE_",
+                f"graph_{nnp}_{padded_curr_iter}_freeze.out",
+            )
+
+            string_list_to_textfile(
+                local_path
+                / f"job_deepmd_freeze_{machine_spec['arch_type']}_{machine}.sh",
+                job_file,
+                read_only=True,
+            )
+            del job_file
+
+            with (local_path / "checkpoint").open("w") as f:
+                f.write('model_checkpoint_path: "model.ckpt"\n')
+                f.write('all_model_checkpoint_paths: "model.ckpt"\n')
+            del f
+            if (
+                local_path
+                / f"job_deepmd_freeze_{machine_spec['arch_type']}_{machine}.sh"
+            ).is_file():
+                change_directory(local_path)
+                try:
+                    subprocess.run(  # noqa: S603
+                        [
+                            machine_launch_command,
+                            f"./job_deepmd_freeze_{machine_spec['arch_type']}_{machine}.sh",
+                        ]
+                    )
+                    arcann_logger.info(f"DP Freeze - '{nnp}' launched.")
+                    completed_count += 1
+                except FileNotFoundError:
+                    arcann_logger.critical(
+                        f"DP Freeze - '{nnp}' NOT launched - '{machine_launch_command}' not found."
+                    )
+                change_directory(local_path.parent)
+            else:
+                arcann_logger.critical(
+                    f"DP Freeze - '{nnp}' NOT launched - No job file."
+                )
+            del local_path
+
+        del nnp, master_job_file, user_machine_keyword, walltime_approx_s
 
     arcann_logger.info("-" * 88)
     # Update the boolean in the training JSON
-    if completed_count == main_json["nnp_count"]:
+    if completed_count == main_json["nnp_count"] or nnp_program == "mace":
         training_json["is_freeze_launched"] = True
 
     # Dump the JSON files (main, training and current input)
@@ -294,6 +305,13 @@ def main(
     if completed_count == main_json["nnp_count"]:
         arcann_logger.info(
             f"Step: {current_step.capitalize()} - Phase: {current_phase.capitalize()} is a success!"
+        )
+    elif nnp_program == "mace":
+        arcann_logger.info(
+            f"Step: {current_step.capitalize()} - Phase: {current_phase.capitalize()} is a success!"
+        )
+        arcann_logger.info(
+            "BUT BE CARREFUL, you're using a MACE model that doesn't require freezing, so no job was launched."
         )
     else:
         arcann_logger.critical(
@@ -314,7 +332,6 @@ def main(
         user_input_json_present,
         user_input_json_filename,
     )
-    del user_machine_keyword, walltime_approx_s
     del main_json, current_input_json, training_json
     del curr_iter, padded_curr_iter
     del (

--- a/arcann_training/training/increment.py
+++ b/arcann_training/training/increment.py
@@ -55,6 +55,9 @@ def main(
     control_path = training_path / "control"
     main_json = load_json_file((control_path / "config.json"))
     training_json = load_json_file((control_path / f"training_{padded_curr_iter}.json"))
+    nnp_program: str = main_json["nnp_program"]
+
+    arcann_logger.info(f"Using {nnp_program} as NNP software")
 
     # Check if we can continue
     if not training_json["is_frozen"]:
@@ -62,13 +65,18 @@ def main(
         arcann_logger.error("Aborting...")
         return 1
 
-    # Check if pb files are present and delete temp files
+    # Check if pb or model files are present and delete temp files
     for nnp in range(1, main_json["nnp_count"] + 1):
         local_path = Path().resolve() / f"{nnp}"
-        check_file_existence(local_path / f"graph_{nnp}_{padded_curr_iter}.pb")
-        if training_json["is_compressed"]:
+        if nnp_program == "deepmd":
+            check_file_existence(local_path / f"graph_{nnp}_{padded_curr_iter}.pb")
+            if training_json["is_compressed"]:
+                check_file_existence(
+                    local_path / f"graph_{nnp}_{padded_curr_iter}_compressed.pb"
+                )
+        elif nnp_program == "mace":
             check_file_existence(
-                local_path / f"graph_{nnp}_{padded_curr_iter}_compressed.pb"
+                local_path / "MACE_models" / f"model_{nnp}_{padded_curr_iter}.model"
             )
 
     # Prepare the test folder
@@ -84,14 +92,36 @@ def main(
         ]
     )
 
-    # Copy the pb files to the NNP meta folder
+    # Copy the pb or model files to the NNP meta folder
     (training_path / "NNP").mkdir(exist_ok=True)
     check_directory(training_path / "NNP")
 
     local_path = Path().resolve()
 
     for nnp in range(1, main_json["nnp_count"] + 1):
-        if training_json["is_compressed"]:
+        if nnp_program == "deepmd":
+            if training_json["is_compressed"]:
+                subprocess.run(  # noqa: S603
+                    [  # noqa: S607
+                        "rsync",
+                        "-a",
+                        str(
+                            local_path
+                            / f"{nnp}"
+                            / f"graph_{nnp}_{padded_curr_iter}_compressed.pb"
+                        ),
+                        str((training_path / "NNP")),
+                    ]
+                )
+            subprocess.run(  # noqa: S603
+                [  # noqa: S607
+                    "rsync",
+                    "-a",
+                    str(local_path / f"{nnp}" / f"graph_{nnp}_{padded_curr_iter}.pb"),
+                    str((training_path / "NNP")),
+                ]
+            )
+        elif nnp_program == "mace":
             subprocess.run(  # noqa: S603
                 [  # noqa: S607
                     "rsync",
@@ -99,19 +129,12 @@ def main(
                     str(
                         local_path
                         / f"{nnp}"
-                        / f"graph_{nnp}_{padded_curr_iter}_compressed.pb"
+                        / "MACE_models"
+                        / f"model_{nnp}_{padded_curr_iter}.model"
                     ),
                     str((training_path / "NNP")),
                 ]
             )
-        subprocess.run(  # noqa: S603
-            [  # noqa: S607
-                "rsync",
-                "-a",
-                str(local_path / f"{nnp}" / f"graph_{nnp}_{padded_curr_iter}.pb"),
-                str((training_path / "NNP")),
-            ]
-        )
     del nnp
 
     # Next iteration

--- a/arcann_training/training/increment.py
+++ b/arcann_training/training/increment.py
@@ -11,9 +11,9 @@ Last modified: 2024/05/15
 
 # Standard library modules
 import logging
+import subprocess
 import sys
 from pathlib import Path
-import subprocess
 
 # Local imports
 from arcann_training.common.check import validate_step_folder
@@ -32,7 +32,7 @@ def main(
     arcann_logger = logging.getLogger("ArcaNN")
 
     # Get the current path and set the training path as the parent of the current path
-    current_path = Path(".").resolve()
+    current_path = Path().resolve()
     training_path = current_path.parent
 
     # Log the step and phase of the program
@@ -42,7 +42,7 @@ def main(
     arcann_logger.debug(f"Current path :{current_path}")
     arcann_logger.debug(f"Training path: {training_path}")
     arcann_logger.debug(f"Program path: {deepmd_iterative_path}")
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
 
     # Check if the current folder is correct for the current step
     validate_step_folder(current_step)
@@ -58,15 +58,13 @@ def main(
 
     # Check if we can continue
     if not training_json["is_frozen"]:
-        arcann_logger.error(
-            f"Lock found. Please execute 'training check_freeze' first."
-        )
-        arcann_logger.error(f"Aborting...")
+        arcann_logger.error("Lock found. Please execute 'training check_freeze' first.")
+        arcann_logger.error("Aborting...")
         return 1
 
     # Check if pb files are present and delete temp files
     for nnp in range(1, main_json["nnp_count"] + 1):
-        local_path = Path(".").resolve() / f"{nnp}"
+        local_path = Path().resolve() / f"{nnp}"
         check_file_existence(local_path / f"graph_{nnp}_{padded_curr_iter}.pb")
         if training_json["is_compressed"]:
             check_file_existence(
@@ -77,8 +75,8 @@ def main(
     (training_path / f"{padded_curr_iter}-test").mkdir(exist_ok=True)
     check_directory((training_path / f"{padded_curr_iter}-test"))
 
-    subprocess.run(
-        [
+    subprocess.run(  # noqa: S603
+        [  # noqa: S607
             "rsync",
             "-a",
             f"{training_path / 'data'}",
@@ -90,12 +88,12 @@ def main(
     (training_path / "NNP").mkdir(exist_ok=True)
     check_directory(training_path / "NNP")
 
-    local_path = Path(".").resolve()
+    local_path = Path().resolve()
 
     for nnp in range(1, main_json["nnp_count"] + 1):
         if training_json["is_compressed"]:
-            subprocess.run(
-                [
+            subprocess.run(  # noqa: S603
+                [  # noqa: S607
                     "rsync",
                     "-a",
                     str(
@@ -106,8 +104,8 @@ def main(
                     str((training_path / "NNP")),
                 ]
             )
-        subprocess.run(
-            [
+        subprocess.run(  # noqa: S603
+            [  # noqa: S607
                 "rsync",
                 "-a",
                 str(local_path / f"{nnp}" / f"graph_{nnp}_{padded_curr_iter}.pb"),
@@ -126,7 +124,7 @@ def main(
         check_directory(training_path / f"{padded_next_iter}-{step}")
     del step
 
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
     # Update the boolean in the training JSON
     training_json["is_incremented"] = True
 
@@ -149,7 +147,7 @@ def main(
     del main_json, training_json
     del curr_iter, padded_curr_iter, next_iter, padded_next_iter
 
-    arcann_logger.debug(f"LOCAL")
+    arcann_logger.debug("LOCAL")
     arcann_logger.debug(f"{locals()}")
     return 0
 

--- a/arcann_training/training/launch.py
+++ b/arcann_training/training/launch.py
@@ -64,6 +64,11 @@ def main(
     # Get control path and load the main JSON and the training JSON
     control_path = training_path / "control"
     main_json = load_json_file((control_path / "config.json"))
+    nnp_program: str = main_json["nnp_program"]
+
+    arcann_logger.info(f"Using {nnp_program} as NNP software")
+    arcann_logger.info("-" * 88)
+
     training_json = load_json_file((control_path / f"training_{padded_curr_iter}.json"))
 
     user_machine_keyword = current_input_json["user_machine_keyword_train"]
@@ -123,14 +128,15 @@ def main(
     for nnp in range(1, main_json["nnp_count"] + 1):
         local_path = current_path / f"{nnp}"
         if (
-            local_path / f"job_deepmd_train_{machine_spec['arch_type']}_{machine}.sh"
+            local_path
+            / f"job_{nnp_program}_train_{machine_spec['arch_type']}_{machine}.sh"
         ).is_file():
             change_directory(local_path)
             try:
                 subprocess.run(  # noqa: S603
                     [
                         machine_launch_command,
-                        f"./job_deepmd_train_{machine_spec['arch_type']}_{machine}.sh",
+                        f"./job_{nnp_program}_train_{machine_spec['arch_type']}_{machine}.sh",
                     ]
                 )
                 arcann_logger.info(f"DP Train - '{nnp}' launched.")

--- a/arcann_training/training/launch.py
+++ b/arcann_training/training/launch.py
@@ -155,6 +155,11 @@ def main(
     # Update the boolean in the training JSON
     if completed_count == main_json["nnp_count"]:
         training_json["is_launched"] = True
+    if nnp_program == "mace":  # because we don't need them for mace
+        training_json["is_freeze_launched"] = True
+        training_json["is_frozen"] = True
+        training_json["is_compress_launched"] = True
+        training_json["is_compressed"] = True
 
     # Dump the JSON (training JSON)
     write_json_file(

--- a/arcann_training/training/launch.py
+++ b/arcann_training/training/launch.py
@@ -11,9 +11,9 @@ Last modified: 2024/05/15
 
 # Standard library modules
 import logging
+import subprocess
 import sys
 from pathlib import Path
-import subprocess
 
 # Local imports
 from arcann_training.common.check import validate_step_folder
@@ -36,7 +36,7 @@ def main(
     arcann_logger = logging.getLogger("ArcaNN")
 
     # Get the current path and set the training path as the parent of the current path
-    current_path = Path(".").resolve()
+    current_path = Path().resolve()
     training_path = current_path.parent
 
     # Log the step and phase of the program
@@ -46,7 +46,7 @@ def main(
     arcann_logger.debug(f"Current path :{current_path}")
     arcann_logger.debug(f"Training path: {training_path}")
     arcann_logger.debug(f"Program path: {deepmd_iterative_path}")
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
 
     # Check if the current folder is correct for the current step
     validate_step_folder(current_step)
@@ -104,18 +104,18 @@ def main(
 
     # Check if we can continue
     if training_json["is_launched"]:
-        arcann_logger.critical(f"Already launched...")
+        arcann_logger.critical("Already launched...")
         continuing = input(
-            f"Do you want to continue?\n['Y' for yes, anything else to abort]\n"
+            "Do you want to continue?\n['Y' for yes, anything else to abort]\n"
         )
         if continuing == "Y":
             del continuing
         else:
-            arcann_logger.error(f"Aborting...")
+            arcann_logger.error("Aborting...")
             return 0
     if not training_json["is_prepared"]:
-        arcann_logger.error(f"Lock found. Please execute 'training prepare' first.")
-        arcann_logger.error(f"Aborting...")
+        arcann_logger.error("Lock found. Please execute 'training prepare' first.")
+        arcann_logger.error("Aborting...")
         return 1
 
     # Launch the jobs
@@ -127,7 +127,7 @@ def main(
         ).is_file():
             change_directory(local_path)
             try:
-                subprocess.run(
+                subprocess.run(  # noqa: S603
                     [
                         machine_launch_command,
                         f"./job_deepmd_train_{machine_spec['arch_type']}_{machine}.sh",
@@ -145,7 +145,7 @@ def main(
         del local_path
     del nnp
 
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
     # Update the boolean in the training JSON
     if completed_count == main_json["nnp_count"]:
         training_json["is_launched"] = True
@@ -158,7 +158,7 @@ def main(
     )
 
     # End
-    arcann_logger.info(f"-" * 88)
+    arcann_logger.info("-" * 88)
     if completed_count == main_json["nnp_count"]:
         arcann_logger.info(
             f"Step: {current_step.capitalize()} - Phase: {current_phase.capitalize()} is a success!"
@@ -167,9 +167,9 @@ def main(
         arcann_logger.critical(
             f"Step: {current_step.capitalize()} - Phase: {current_phase.capitalize()} is semi-success!"
         )
-        arcann_logger.critical(f"Some jobs did not launch correctly.")
+        arcann_logger.critical("Some jobs did not launch correctly.")
         arcann_logger.critical(
-            f"Please launch manually before continuing to the next step."
+            "Please launch manually before continuing to the next step."
         )
         arcann_logger.critical(
             f"Replace the key 'is_launched' to 'True' in the 'training_{padded_curr_iter}.json'."
@@ -192,7 +192,7 @@ def main(
         machine_max_array_size,
     )
 
-    arcann_logger.debug(f"LOCAL")
+    arcann_logger.debug("LOCAL")
     arcann_logger.debug(f"{locals()}")
     return 0
 
@@ -202,7 +202,7 @@ if __name__ == "__main__":
         main(
             "training",
             "launch",
-            Path(sys.argv[1]),
+            deepmd_iterative_path=Path(sys.argv[1]),
             fake_machine=sys.argv[2],
             user_input_json_filename=sys.argv[3],
         )

--- a/arcann_training/training/prepare.py
+++ b/arcann_training/training/prepare.py
@@ -331,6 +331,32 @@ def main(
         nnp_input["forces_key"] = "REF_forces"
         nnp_input["virials_key"] = "REF_virials"
 
+        if "E0s" not in nnp_input or not isinstance(nnp_input["E0s"], dict):
+            arcann_logger.critical(
+                "It is HIGHLY recommanded when training MACE model, to do it by providing the energies of the isolated atoms."
+                "To do so, please provide these E0s by computing the energies of the isolated atoms with the same level of theory as the one used for the training dataset."
+            )
+        else:
+            e0_atoms = set(nnp_input["E0s"].keys())
+            system_atoms = [
+                main_json["properties"][element]["symbol"]
+                for element in main_json["properties"]
+            ]
+            elements = load_json_file(
+                deepmd_iterative_path / "assets" / "elements.json"
+            )
+            system_atoms = [
+                elm["atomic_number"]
+                for elm in elements.values()
+                if elm["symbol"] in system_atoms
+            ]
+            system_atoms = set(system_atoms)
+            if e0_atoms != system_atoms:
+                arcann_logger.error(
+                    f"The atoms provided for E0s don't match with the one on your systems. E0 atoms: {e0_atoms}, system atoms: {system_atoms}."
+                )
+                arcann_logger.error("Aborting...")
+                return 1
         arcann_logger.debug(f"mace_input: {nnp_input}")
 
     arcann_logger.debug(f"main_json: {main_json}")

--- a/arcann_training/training/prepare.py
+++ b/arcann_training/training/prepare.py
@@ -11,8 +11,9 @@ Last modified: 2026/02/06
 
 # Standard library modules
 import logging
+import os
 import random
-import subprocess
+import shutil
 import sys
 from copy import deepcopy
 from pathlib import Path
@@ -48,6 +49,7 @@ from arcann_training.training.utils import (
     calculate_decay_steps,
     generate_training_json,
     validate_deepmd_config,
+    validate_mace_config,
 )
 
 
@@ -221,6 +223,7 @@ def main(
         arcann_logger.info(
             f"Using DeePMD version: {current_input_json['deepmd_model_version']}"
         )
+
     elif "mace_model_version" not in user_input_json and nnp_program == "mace":
         macetrain_list = list(
             (current_path.parent / "user_files").glob("*.yml")
@@ -286,7 +289,7 @@ def main(
             / f"dptrain_{training_json['deepmd_model_version']}.json"
         ).resolve()
 
-        dp_train_input = load_json_file(dp_train_input_path)
+        nnp_input = load_json_file(dp_train_input_path)
         if "type_map" not in main_json:
             type_map = [
                 main_json["properties"][element]["symbol"]
@@ -295,18 +298,19 @@ def main(
             main_json["type_map"] = type_map
 
         # Make sure they are the same
-        if dp_train_input["model"]["type_map"] != main_json["type_map"]:
+        if nnp_input["model"]["type_map"] != main_json["type_map"]:
             arcann_logger.error(
                 f"Type map in {dp_train_input_path} does not match the one in config.json."
             )
             arcann_logger.error("Aborting...")
             return 1
 
-        # main_json["type_map"] = {}
-        # main_json["type_map"] = dp_train_input["model"]["type_map"]
         del dp_train_input_path
-        arcann_logger.debug(f"dp_train_input: {dp_train_input}")
+        arcann_logger.debug(f"dp_train_input: {nnp_input}")
+
     elif nnp_program == "mace":
+        validate_mace_config(training_json)
+
         mace_input_path = (
             training_path
             / "user_files"
@@ -320,23 +324,14 @@ def main(
                 / f"mace_{training_json['mace_model_version']}.yaml"
             ).resolve()
 
-        mace_input = load_yaml_file(mace_input_path)
+        nnp_input = load_yaml_file(mace_input_path)
 
-        if "type_map" not in main_json:
-            type_map = [
-                main_json["properties"][element]["symbol"]
-                for element in main_json["properties"]
-            ]
-            main_json["type_map"] = type_map
+        # control the key to align with MACE references
+        nnp_input["energy_key"] = "REF_energy"
+        nnp_input["forces_key"] = "REF_forces"
+        nnp_input["virials_key"] = "REF_virials"
 
-        training_json |= {
-            "mace_dtype": mace_input.get("default_dtype", "float64"),
-            "mace_model_dir": mace_input.get(
-                "model_dir", mace_input.get("work_dir", None)
-            ),
-        }
-
-        arcann_logger.debug(f"mace_input: {mace_input}")
+        arcann_logger.debug(f"mace_input: {nnp_input}")
 
     arcann_logger.debug(f"main_json: {main_json}")
 
@@ -428,80 +423,91 @@ def main(
 
     if nnp_program == "deepmd":
         # Update the inputs with the sets
-        dp_train_input["training"]["training_data"]["systems"] = [
+        nnp_input["training"]["training_data"]["systems"] = [
             "data/" + ds for ds in dataset.training_paths
         ]
-        dp_train_input["training"]["validation_data"]["systems"] = [
+        nnp_input["training"]["validation_data"]["systems"] = [
             "data/" + ds for ds in dataset.validation_paths
         ]
+    elif nnp_program == "mace":
+        nnp_input["train_file"] = "data/training_dataset.extxyz"
+        nnp_input["valid_file"] = "data/validation_dataset.extxyz"
+        nnp_input["test_file"] = "data/test_dataset.extxyz"
 
     # Here calculate the parameters
-    # decay_steps it auto-recalculated as funcion of trained_count
-    arcann_logger.debug(f"training_json - decay_steps: {training_json['decay_steps']}")
-    arcann_logger.debug(
-        f"current_input_json - decay_steps: {current_input_json['decay_steps']}"
-    )
-    if not training_json["decay_steps_fixed"]:
-        decay_steps = calculate_decay_steps(
-            training_json["training_count"]["total"], training_json["decay_steps"]
-        )
-        arcann_logger.debug("Recalculating decay_steps")
-        # Update the training JSON and the merged input JSON
-        training_json["decay_steps"] = decay_steps
-        current_input_json["decay_steps"] = decay_steps
-    else:
-        decay_steps = training_json["decay_steps"]
-    arcann_logger.debug(f"decay_steps: {decay_steps}")
-    arcann_logger.debug(f"training_json - decay_steps: {training_json['decay_steps']}")
-    arcann_logger.debug(
-        f"current_input_json - decay_steps: {current_input_json['decay_steps']}"
-    )
-
-    # numb_steps and decay_rate
-    arcann_logger.debug(
-        f"training_json - numb_steps / decay_rate: {training_json['numb_steps']} / {training_json['decay_rate']}"
-    )
-    arcann_logger.debug(
-        f"current_input_json - numb_steps / decay_rate: {current_input_json['numb_steps']} / {current_input_json['decay_rate']}"
-    )
-    numb_steps = training_json["numb_steps"]
-    decay_rate_new = calculate_decay_rate(
-        numb_steps,
-        training_json["start_lr"],
-        training_json["stop_lr"],
-        training_json["decay_steps"],
-    )
-    while decay_rate_new < training_json["decay_rate"]:
+    # decay_steps it auto-recalculated as funcion of trained_count only for DeepMD
+    if nnp_program == "deepmd":
         arcann_logger.debug(
-            f"numb_steps is too small to allow for the decay_rate, increasing numb_steps: {decay_rate_new} < {training_json['decay_rate']}"
+            f"training_json - decay_steps: {training_json['decay_steps']}"
         )
-        numb_steps = numb_steps + 10000
+        arcann_logger.debug(
+            f"current_input_json - decay_steps: {current_input_json['decay_steps']}"
+        )
+        if not training_json["decay_steps_fixed"]:
+            decay_steps = calculate_decay_steps(
+                training_json["training_count"]["total"], training_json["decay_steps"]
+            )
+            arcann_logger.debug("Recalculating decay_steps")
+            # Update the training JSON and the merged input JSON
+            training_json["decay_steps"] = decay_steps
+            current_input_json["decay_steps"] = decay_steps
+        else:
+            decay_steps = training_json["decay_steps"]
+        arcann_logger.debug(f"decay_steps: {decay_steps}")
+        arcann_logger.debug(
+            f"training_json - decay_steps: {training_json['decay_steps']}"
+        )
+        arcann_logger.debug(
+            f"current_input_json - decay_steps: {current_input_json['decay_steps']}"
+        )
+
+        # numb_steps and decay_rate
+        arcann_logger.debug(
+            f"training_json - numb_steps / decay_rate: {training_json['numb_steps']} / {training_json['decay_rate']}"
+        )
+        arcann_logger.debug(
+            f"current_input_json - numb_steps / decay_rate: {current_input_json['numb_steps']} / {current_input_json['decay_rate']}"
+        )
+        numb_steps = training_json["numb_steps"]
         decay_rate_new = calculate_decay_rate(
             numb_steps,
             training_json["start_lr"],
             training_json["stop_lr"],
             training_json["decay_steps"],
         )
-    # Update the training JSON and the merged input JSON
-    training_json["numb_steps"] = int(numb_steps)
-    training_json["decay_rate"] = decay_rate_new
-    current_input_json["numb_steps"] = int(numb_steps)
-    current_input_json["decay_rate"] = decay_rate_new
-    arcann_logger.debug(f"numb_steps: {numb_steps}")
-    arcann_logger.debug(f"decay_rate: {decay_rate_new}")
-    arcann_logger.debug(
-        f"training_json - numb_steps / decay_rate: {training_json['numb_steps']} / {training_json['decay_rate']}"
-    )
-    arcann_logger.debug(
-        f"current_input_json - numb_steps / decay_rate: {current_input_json['numb_steps']} / {current_input_json['decay_rate']}"
-    )
+        while decay_rate_new < training_json["decay_rate"]:
+            arcann_logger.debug(
+                f"numb_steps is too small to allow for the decay_rate, increasing numb_steps: {decay_rate_new} < {training_json['decay_rate']}"
+            )
+            numb_steps = numb_steps + 10000
+            decay_rate_new = calculate_decay_rate(
+                numb_steps,
+                training_json["start_lr"],
+                training_json["stop_lr"],
+                training_json["decay_steps"],
+            )
+        # Update the training JSON and the merged input JSON
+        training_json["numb_steps"] = int(numb_steps)
+        training_json["decay_rate"] = decay_rate_new
+        current_input_json["numb_steps"] = int(numb_steps)
+        current_input_json["decay_rate"] = decay_rate_new
+        arcann_logger.debug(f"numb_steps: {numb_steps}")
+        arcann_logger.debug(f"decay_rate: {decay_rate_new}")
+        arcann_logger.debug(
+            f"training_json - numb_steps / decay_rate: {training_json['numb_steps']} / {training_json['decay_rate']}"
+        )
+        arcann_logger.debug(
+            f"current_input_json - numb_steps / decay_rate: {current_input_json['numb_steps']} / {current_input_json['decay_rate']}"
+        )
 
-    del decay_steps, numb_steps, decay_rate_new
+        del decay_steps, numb_steps, decay_rate_new
+        nnp_input["training"]["numb_steps"] = training_json["numb_steps"]
+        nnp_input["learning_rate"]["decay_steps"] = training_json["decay_steps"]
+        nnp_input["learning_rate"]["stop_lr"] = training_json["stop_lr"]
 
-    if nnp_program == "deepmd":
-        dp_train_input["training"]["numb_steps"] = training_json["numb_steps"]
-        dp_train_input["learning_rate"]["decay_steps"] = training_json["decay_steps"]
-        dp_train_input["learning_rate"]["stop_lr"] = training_json["stop_lr"]
+    elif nnp_program == "mace":
+        nnp_input["max_num_epochs"] = training_json["max_num_epochs"]
+        # TODO se pencher sur le lr, est-ce que c'est possible dans mace et comment?
 
     # Set booleans in the training JSON
     training_json = {
@@ -517,32 +523,38 @@ def main(
     }
 
     # Rsync data to local data
+    # TODO not rsync, maybe just symlink + compress everything into one big dataset + possibly convert depending on the NNP
+
     localdata_path = current_path / "data"
     localdata_path.mkdir(exist_ok=True)
-    for train_dataset in dataset.training_paths:
-        subprocess.run(
-            [
-                "rsync",
-                "-a",
-                f"{training_path / 'data' / train_dataset}",
-                f"{localdata_path}",
-            ]
-        )
-    for valid_dataset in dataset.validation_paths:
-        subprocess.run(
-            [
-                "rsync",
-                "-a",
-                f"{training_path / 'data' / valid_dataset}",
-                f"{localdata_path}",
-            ]
-        )
-    del train_dataset, localdata_path
+    if nnp_program == "deepmd":
+        for train_dataset in dataset.training_paths:
+            target_path = localdata_path / train_dataset
+            if target_path.exists():
+                shutil.rmtree(target_path)
+            shutil.copytree(
+                training_path / "data" / train_dataset,
+                target_path,
+                copy_function=os.link,
+            )
+        for valid_dataset in dataset.validation_paths:
+            target_path = localdata_path / valid_dataset
+            if target_path.exists():
+                shutil.rmtree(target_path)
+            shutil.copytree(
+                training_path / "data" / valid_dataset,
+                target_path,
+                copy_function=os.link,
+            )
+        del train_dataset, valid_dataset, localdata_path
+
+    elif nnp_program == "mace":
+        dataset.prepare_for_mace_train(data_path=localdata_path)
 
     if nnp_program == "deepmd":
         # Change some inside output
-        dp_train_input["training"]["disp_file"] = "lcurve.out"
-        dp_train_input["training"]["save_ckpt"] = "model.ckpt"
+        nnp_input["training"]["disp_file"] = "lcurve.out"
+        nnp_input["training"]["save_ckpt"] = "model.ckpt"
 
     arcann_logger.debug(f"training_json: {training_json}")
     arcann_logger.debug(f"user_input_json: {user_input_json}")
@@ -607,26 +619,26 @@ def main(
         check_directory(local_path)
 
         random.seed()
-        random_0_1000 = random.randrange(0, 1000)
+        random_0_1000 = random.randrange(0, 1000)  # noqa: S311
         if nnp_program == "deepmd":
             replace_values_by_key_name(
-                dp_train_input, "seed", int(f"{nnp}{random_0_1000}{padded_curr_iter}")
+                nnp_input, "seed", int(f"{nnp}{random_0_1000}{padded_curr_iter}")
             )
 
             dp_train_input_file = (Path(f"{nnp}") / "training.json").resolve()
 
             write_json_file(
-                dp_train_input,
+                nnp_input,
                 dp_train_input_file,
                 enable_logging=False,
                 read_only=True,
             )
         elif nnp_program == "mace":
-            mace_input["seed"] = int(f"{nnp}{random_0_1000}{padded_curr_iter}")
-            mace_input["name"] = f"model_{nnp}_{padded_curr_iter}"
+            nnp_input["seed"] = int(f"{nnp}{random_0_1000}{padded_curr_iter}")
+            nnp_input["name"] = f"model_{nnp}_{padded_curr_iter}"
             mace_input_file = (Path(f"{nnp}") / "training.yaml").resolve()
             write_yaml_file(
-                mace_input, mace_input_file, enable_logging=False, read_only=True
+                nnp_input, mace_input_file, enable_logging=False, read_only=True
             )
 
         job_file = replace_in_slurm_file_general(
@@ -653,11 +665,12 @@ def main(
             job_file = replace_substring_in_string_list(
                 job_file, "_R_DEEPMD_OUTPUT_FILE_", "training.out"
             )
+
         elif nnp_program == "mace":
             # Replace the inputs/variables in the job file
             job_file = replace_substring_in_string_list(
                 job_file, "_R_MACE_VERSION_", f"{training_json['mace_model_version']}"
-            )
+            )  # maybe not a version but a repo
             job_file = replace_substring_in_string_list(
                 job_file, "_R_MACE_INPUT_FILE_", "training.yaml"
             )

--- a/arcann_training/training/prepare.py
+++ b/arcann_training/training/prepare.py
@@ -662,6 +662,7 @@ def main(
         elif nnp_program == "mace":
             nnp_input["seed"] = int(f"{nnp}{random_0_1000}{padded_curr_iter}")
             nnp_input["name"] = f"model_{nnp}_{padded_curr_iter}"
+            nnp_input["model_dir"] = "MACE_models"
             mace_input_file = (Path(f"{nnp}") / "training.yaml").resolve()
             write_yaml_file(
                 nnp_input, mace_input_file, enable_logging=False, read_only=True

--- a/arcann_training/training/utils.py
+++ b/arcann_training/training/utils.py
@@ -35,10 +35,10 @@ validate_deepmd_config(training_config) -> None
 # TODO: Homogenize the docstrings for this module
 
 # Standard library modules
-from pathlib import Path
-from copy import deepcopy
-from typing import Dict, Tuple
 import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Dict, Tuple
 
 # Third-party modules
 import numpy as np
@@ -134,12 +134,12 @@ def calculate_decay_steps(num_structures: int, min_decay_steps: int = 5000) -> i
     """
     # Check if num_structures is a positive integer
     if not isinstance(num_structures, int) or num_structures <= 0:
-        error_msg = f"The argument 'num_structures' must be a positive integer."
+        error_msg = "The argument 'num_structures' must be a positive integer."
         raise ValueError(error_msg)
 
     # Check if min_decay_steps is a positive integer
     if not isinstance(min_decay_steps, int) or min_decay_steps <= 0:
-        error_msg = f"The argument 'min_decay_steps' must be a positive integer."
+        error_msg = "The argument 'min_decay_steps' must be a positive integer."
         raise ValueError(error_msg)
 
     # Round down to the nearest multiple of 10000
@@ -188,11 +188,11 @@ def calculate_decay_rate(
     """
     # Check that the start learning rate is a positive number.
     if start_lr <= 0 or not isinstance(start_lr, (int, float)):
-        error_msg = f"The argument 'start_lr' must be a positive number."
+        error_msg = "The argument 'start_lr' must be a positive number."
         raise ValueError(error_msg)
 
     if decay_steps <= 0 or not isinstance(decay_steps, int):
-        error_msg = f"The argument 'decay_steps' must be a positive integer."
+        error_msg = "The argument 'decay_steps' must be a positive integer."
         raise ValueError(error_msg)
 
     # Calculate the decay rate using the given training parameters
@@ -237,10 +237,10 @@ def calculate_learning_rate(
         isinstance(arg, (int, float))
         for arg in (current_step, start_lr, decay_rate, decay_steps)
     ):
-        error_msg = f"All arguments must be positive."
+        error_msg = "All arguments must be positive."
         raise ValueError(error_msg)
     if not isinstance(decay_steps, int):
-        error_msg = f"The argument 'decay_steps' must be a positive integer."
+        error_msg = "The argument 'decay_steps' must be a positive integer."
         raise ValueError(error_msg)
 
     # Calculate the learning rate based on the current training step

--- a/arcann_training/training/utils.py
+++ b/arcann_training/training/utils.py
@@ -42,6 +42,7 @@ from typing import Dict, Tuple
 
 # Third-party modules
 import numpy as np
+from packaging import version
 
 # Local imports
 from arcann_training.common.utils import catch_errors_decorator
@@ -337,4 +338,33 @@ def validate_deepmd_config(training_config) -> None:
         or float(training_config["deepmd_model_version"]) > 3.0
     ):
         error_msg = f"Only 2.x and 3.0 versions of deepmd are suppported: '{training_config['deepmd_model_version']}'."
+        raise ValueError(error_msg)
+
+
+@catch_errors_decorator
+def validate_mace_config(training_config) -> None:
+    """
+    Validate the provided training configuration for a MACE model.
+
+    Parameters
+    ----------
+    training_config : dict
+        A dictionary containing the training configuration.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ValueError
+        If mace_model_version is not 0.3x
+        If the configuration is not valid with respect to machine/arch_name/arch and MACE.
+    """
+    # Check MACE version
+    current = version.parse(training_config["mace_model_version"])
+    min_v = version.parse("0.3.0")
+    max_v = version.parse("0.4.0")
+    if current < min_v or current >= max_v:
+        error_msg = f"Only versions 0.3x of MACE are suppported: '{training_config['mace_model_version']}'."
         raise ValueError(error_msg)

--- a/examples/inputs/training.json
+++ b/examples/inputs/training.json
@@ -15,5 +15,6 @@
     "decay_steps": { "value": null, "_comment": "int", "_default": 5000},
     "decay_steps_fixed": { "value": null, "_comment": "boolean", "_default": false},
     "numb_steps": { "value": null, "_comment": "int", "_default": 400000},
+    "max_num_epochs": { "value": null, "_comment": "int", "_default": 5000},
     "numb_test": { "value": null, "_comment": "int", "_default": 0}
 }

--- a/examples/user_files/job_training_mace_slurm/job_mace_train_gpu_myHPCkeyword1.sh
+++ b/examples/user_files/job_training_mace_slurm/job_mace_train_gpu_myHPCkeyword1.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+#----------------------------------------------------------------------------------------------------#
+#   ArcaNN: Automatic training of Reactive Chemical Architecture with Neural Networks                #
+#   Copyright 2022-2024 ArcaNN developers group <https://github.com/arcann-chem>                     #
+#                                                                                                    #
+#   SPDX-License-Identifier: AGPL-3.0-only                                                           #
+#----------------------------------------------------------------------------------------------------#
+# Created: 2026/02/25
+# Last modified: 2026/02/25
+#----------------------------------------------
+# You must keep the _R_VARIABLES_ in the file.
+# You must keep the name file as job_deepmd_train_ARCHTYPE_myHPCkeyword.sh.
+#----------------------------------------------
+# Project/Account
+#SBATCH --account=_R_PROJECT_@_R_ALLOC_
+# QoS/Partition/SubPartition
+#SBATCH --qos=_R_QOS_
+#SBATCH --partition=_R_PARTITION_
+#SBATCH -C _R_SUBPARTITION_
+# Number of Nodes/MPIperNodes/OpenMPperMPI/GPU
+#SBATCH --nodes 1
+#SBATCH --ntasks-per-node 1
+#SBATCH --cpus-per-task 10
+#SBATCH --hint=nomultithread
+#SBATCH --gres=gpu:1
+# Walltime
+#SBATCH -t _R_WALLTIME_
+# Merge Output/Error
+#SBATCH -o MACE_Train.%j
+#SBATCH -e MACE_Train.%j
+# Name of job
+#SBATCH -J MACE_Train
+# Email
+#SBATCH --mail-type FAIL,BEGIN,END,ALL
+#SBATCH --mail-user _R_EMAIL_
+#
+
+#----------------------------------------------
+# Files / Variables - They should not be changed
+#----------------------------------------------
+
+MACE_MODEL_VERSION="_R_MACE_VERSION_"
+MACE_IN_FILE="_R_MACE_INPUT_FILE_"
+MACE_LOG_FILE="_R_MACE_LOG_FILE_"
+MACE_OUT_FILE="_R_MACE_OUTPUT_FILE_"
+MACE_DATA_DIR="../data"
+
+MACE_CONDA_INSTALL="" #If you don't want to use a specific version of MACE, but rather your own you installed on a conda env, specify the path of this env here
+
+#----------------------------------------------
+# Adapt the following lines to your HPC system
+#----------------------------------------------
+
+# Go where the job has been launched
+cd "${SLURM_SUBMIT_DIR}" || { echo "Could not go to ${SLURM_SUBMIT_DIR}. Aborting..."; exit 1; }
+
+# Check
+[ -f "${MACE_IN_FILE}" ] || { echo "${MACE_IN_FILE} does not exist. Aborting..."; exit 1; }
+
+# This part copy the data from the MACE_DATA_DIR to the job folder (because they are one up and they should be in the same folder)
+[ -d ${MACE_DATA_DIR} ] || { echo "${MACE_DATA_DIR} does not exist. Aborting..."; exit 1; }
+mkdir -p "${SLURM_SUBMIT_DIR}"/data || { echo "Could not create ${SLURM_SUBMIT_DIR}/data. Aborting..."; exit 1; }
+{ cp -r ${MACE_DATA_DIR}/* "${SLURM_SUBMIT_DIR}"/data && echo "${MACE_DATA_DIR} copied successfully"; } || { echo "Could not copy ${MACE_DATA_DIR}. Aborting..."; exit 1; }
+
+# Example to use the DeepMD_MODEL_VERSION variable
+if [ ${MACE_MODEL_VERSION} == "0.3.14" ]; then
+    # Load the MACE module
+    module load mace
+elif [ -n "$MACE_CONDA_INSTALL" ]; then
+    # Activate the conda environment
+    module load conda
+    source ${CONDA_PREFIX}/bin/activate
+    conda activate ${MACE_CONDA_INSTALL}
+else
+    echo "MACE version ${MACE_MODEL_VERSION} is not available. Aborting..."
+    exit 1
+fi
+
+# Run the MACE train
+echo "# [$(date)] Running MACE train..."
+mace_run_train --config=${MACE_IN_FILE} 1> ${MACE_LOG_FILE} 2> ${MACE_OUT_FILE} 
+echo "# [$(date)] MACE train finished."
+
+# This are useless files, so we remove them
+if [ -f out.json ]; then rm out.json; fi
+if [ -f input_v2_compat.json ]; then rm input_v2_compat.json; fi
+
+sleep 2
+exit

--- a/examples/user_files/training_mace/training_0.13.yaml
+++ b/examples/user_files/training_mace/training_0.13.yaml
@@ -1,0 +1,51 @@
+seed: 9
+
+E0s: 
+  1: 0.0,
+  6: -0.0000000000000001,
+
+model: "MACE"
+
+config_type_weights:
+  Default: 1.0
+
+num_channels: 64
+max_L: 1
+r_max: 6.0
+num_interactions: 2
+correlation: 2
+
+energy_key: "REF_energy"
+forces_key: "REF_forces"
+
+name: "train_001"
+
+model_dir: "model/"
+
+train_file: "training_data.extxyz"
+valid_file: "valid_data.extxyz"
+test_file: "test_data.extxyz"
+
+device: cuda
+default_dtype: "float32"
+save_cpu: no
+
+batch_size: 5
+valid_batch_size: 5
+max_num_epochs: 500
+lr: 1e-2
+
+forces_weight: 100
+energy_weight: 1
+
+swa: False
+ema: True
+ema_decay: 0.99
+amsgrad: True
+restart_latest: True
+
+scheduler_patience: 15
+patience: 20
+eval_interval: 1
+
+enable_cueq: False


### PR DESCRIPTION
### What does this PR do?

*(Briefly describe the main purpose of this PR in one or two sentences. What problem does it solve or what feature does it add?)*

All the phases of the `training` step are implemented to support a training done withe MACE.

- MACE training input are handled and are verified to be launched. (especially presence of E0, the right version, the right keywords)
- The training completeness is verified
- The trained models are kept for the further iterations.

### How to test this?

*(Provide clear, step-by-step instructions on how the reviewer can manually test your changes.)*

1. Arm yourself with a dataset in .extxyz format that you will have separated into two parts: init_system.extxyz and init_valid_system.extxyz. (The extxyz keywords for the forces, energies and virials should be respectively `REF_forces`, `REF_energy` and `REF_virials`) Place it the `data/` folder.
2. Provide a nice training file for mace, named according to the used version, for eg. `mace_0.3.15.yaml`.  Do not forget to provide de E0 if you want to train based on the energies of the isolated atoms.
3. Depending on your hpc machine and how you manage to install mace on it, provide the slurm file that will be used to launch the models training. This should be named such as `job_mace_train_gpu_{machine_keyword}.sh`.
4. You should be ready to launch your first training with mace!

Note: The phases `freeze`, `check_freeze`, `compress` and `check_compress` are useless for a mace training, you can eventually skip them. But if you don't, everything will still run smoothly, except of course that no job will be launched.


No test implemented

---

### Related Issues/Tickets

*(Link to any relevant issues.)*

-- 