### PR TITLE
FEAT: independent rerun capability

### DIFF
--- a/arcann_training/common/lammps.py
+++ b/arcann_training/common/lammps.py
@@ -362,6 +362,7 @@ class LAMMPSInputHandler:
                 f"No 'run _R_NUMBER_OF_STEPS_' found in the LAMMPS input file: {self._lmp_input}"
             )
 
+        # TODO: support the 'restart' lammps command
         match_rest = re.search(
             r"^\s*(?!#)write_restart\s+_R_RESTART_OUT_", self._raw_text, re.MULTILINE
         )
@@ -372,11 +373,21 @@ class LAMMPSInputHandler:
             )
 
         run_index = match_run.start()
-        _modified_text = self._raw_text[:run_index] + "\n".join(self.cell_info_lammps)
+
+        _modified_text = (
+            self._raw_text[:run_index] + "\n".join(self.cell_info_lammps) + "\n"
+        )
 
         match self.lmp_pair:
             case LAMMPSPair.MACE | LAMMPSPair.MLIAP | LAMMPSPair.SYMMETRIX:
-                _modified_text += "\n".join(self.mace_dump_0)
+                _modified_text += "\n".join(self.mace_dump_0) + "\n"
+
+                # To do independent rerun, we need a restart file written before run,
+                # as the simulation may break before writing it
+                if run_index < (rest_index := match_rest.start()):
+                    _modified_text += (
+                        self._raw_text[rest_index : match_rest.end()] + "\n"
+                    )
 
         _modified_text += self._raw_text[run_index:] + "\n"
         self._raw_text = _modified_text
@@ -422,7 +433,21 @@ class LAMMPSInputHandler:
         for key, value in variables.items():
             formatted_text = formatted_text.replace(key, value)
 
+        # TODO: this is ugly, needs refactoring
+        if hasattr(self, "mace_rerun_text"):
+            for key, value in variables.items():
+                self.mace_rerun_text = self.mace_rerun_text.replace(key, value)
+
         return formatted_text if not splitlines else formatted_text.splitlines()
+
+    def write(self, file: Path, input_replace_dict: dict[str, str]) -> None:
+        with file.open("w+") as inp:
+            inp.write(self.apply_variables(input_replace_dict))
+
+        match self.lmp_pair:
+            case LAMMPSPair.MACE | LAMMPSPair.MLIAP | LAMMPSPair.SYMMETRIX:
+                with file.with_stem(file.stem + "-rerun").open("w+") as inp_rr:
+                    inp_rr.write(self.mace_rerun_text)
 
     @property
     def lmp_pair(self) -> LAMMPSPair:
@@ -482,13 +507,14 @@ class LAMMPSInputHandler:
             self._raw_text = self.apply_variables({"_R_MODEL_FILES_": " ".join(models)})
         else:
             self._raw_text = self.apply_variables({"_R_MODEL_FILES_": models[0]})
-            self._prepare_mace_rerun()
+            self.mace_rerun_text = self._prepare_mace_rerun()
 
     @catch_errors_decorator
-    def _prepare_mace_rerun(self) -> None:
+    def _prepare_mace_rerun(self) -> str:
+        mace_rerun_text = ""
         for i, model in enumerate(self._models[1:], start=2):
             rr_str = f"Rerun with {to_ordinal(i)} model"
-            self._raw_text += f"""\n# {"-" * len(rr_str)}
+            mace_rerun_text += f"""\n# {"-" * len(rr_str)}
 # {rr_str}
 # {"-" * len(rr_str)}
 clear
@@ -508,6 +534,10 @@ dump_modify traj{i} sort id
 
 rerun {self._lmp_input.stem}_mace_run_model1.lammpstrj dump x y z
 """
+
+        self._raw_text += mace_rerun_text
+
+        return mace_rerun_text
 
     def _get_pair_lmp_string(self, model: str) -> str:
         elements = " ".join(self._el)

--- a/arcann_training/exploration/prepare.py
+++ b/arcann_training/exploration/prepare.py
@@ -299,9 +299,15 @@ def main(
     nb_sim = 0
 
     job_array_params_file = {}
-    job_array_params_file["lammps"] = [
-        f"PATH/_R_{nnp_program.upper()}_VERSION_/_R_MODEL_FILES_/_R_LAMMPS_IN_FILE_/_R_DATA_FILE_/_R_RERUN_FILE_/_R_PLUMED_FILES_/"
-    ]
+    if nnp_program == "deepmd":
+        job_array_params_file["lammps"] = [
+            f"PATH/_R_{nnp_program.upper()}_VERSION_/_R_MODEL_FILES_/_R_LAMMPS_IN_FILE_/_R_DATA_FILE_/_R_RERUN_FILE_/_R_PLUMED_FILES_/"
+        ]
+    else:
+        job_array_params_file["lammps"] = [
+            f"PATH/_R_{nnp_program.upper()}_VERSION_/_R_MODEL_FILES_/_R_LAMMPS_IN_FILE_/_R_DATA_FILE_/_R_RERUN_FILE_/_R_PLUMED_FILES_/_R_MACE_RERUN_FILE_"
+        ]
+
     job_array_params_file["i-PI"] = [
         "PATH/_R_DEEPMD_VERSION_/_R_MODEL_FILES_/_R_INPUT_FILE_/_R_DATA_FILE_/_R_RERUN_FILE_/_R_PLUMED_FILES_/"
     ]
@@ -966,12 +972,10 @@ def main(
                         "print_every_x_steps"
                     ] = int(system_print_every_x_steps)
 
-                    with (
-                        local_path / f"{system_auto}_{nnp_index}_{padded_curr_iter}.in"
-                    ).open("w+") as input:
-                        input.write(
-                            lmp_input_handler.apply_variables(input_replace_dict)
-                        )
+                    lmp_input_handler.write(
+                        local_path / f"{system_auto}_{nnp_index}_{padded_curr_iter}.in",
+                        input_replace_dict,
+                    )
 
                     # ? Use reset or recreate from scratch?
                     lmp_input_handler.reset()  # reset input handler so the next iteration is properly handled
@@ -994,7 +998,6 @@ def main(
                         f"{system_auto}_{nnp_index}_{padded_curr_iter}.in" + "/"
                     )
                     job_array_params_line += f"{system_lammps_data_fn}" + "/"
-                    job_array_params_line += "" + "/"
 
                     # INDIVIDUAL JOB FILE
                     job_file = replace_in_slurm_file_general(
@@ -1033,21 +1036,108 @@ def main(
                     job_file = replace_substring_in_string_list(
                         job_file, "_R_DATA_FILE_", f"{system_lammps_data_fn}"
                     )
-                    job_file = replace_substring_in_string_list(
-                        job_file, ' "_R_RERUN_FILE_"', ""
-                    )
-                    if plumed[0] == 1:
+
+                    if nnp_program == "mace":
                         job_file = replace_substring_in_string_list(
-                            job_file, "_R_PLUMED_FILES_", '" "'.join(plumed_input)
+                            job_file,
+                            "_R_RERUN_FILE_",
+                            f"{system_auto}_{nnp_index}_{padded_curr_iter}-rerun.in",
                         )
-                        job_array_params_line += '" "'.join(plumed_input)
+                        job_array_params_line += (
+                            f"{system_auto}_{nnp_index}_{padded_curr_iter}-rerun.in/"
+                        )
                     else:
                         job_file = replace_substring_in_string_list(
-                            job_file, ' "_R_PLUMED_FILES_"', ""
+                            job_file, ' "_R_RERUN_FILE_"', ""
                         )
+                        job_array_params_line += "/"
+
+                    plumed_inputs = ""
+                    plumed_key = "_R_PLUMED_FILES_"
+
+                    if plumed[0] == 1:
+                        plumed_inputs = '" "'.join(plumed_input)
+                        job_array_params_line += plumed_inputs
+                    else:
+                        plumed_key = ' "_R_PLUMED_FILES_"'
                         job_array_params_line += ""
 
+                    job_file = replace_substring_in_string_list(
+                        job_file, plumed_key, plumed_inputs
+                    )
+
+                    if nnp_program == "mace":
+                        job_file = replace_substring_in_string_list(
+                            job_file,
+                            ' "_R_MACE_RERUN_FILE_"',
+                            f"{system_auto}_{nnp_index}_{padded_curr_iter}-rerun.in",
+                        )
+
+                        job_array_params_line += "/"
+                        job_array_params_line += (
+                            f"{system_auto}_{nnp_index}_{padded_curr_iter}-rerun.in"
+                        )
+
+                        # INDIVIDUAL JOB FILE
+                        rerun_job_file = replace_in_slurm_file_general(
+                            master_job_file[system_exploration_type],
+                            machine_spec,
+                            system_walltime_approx_s,
+                            machine_walltime_format,
+                            current_input_json["job_email"],
+                        )
+                        # Replace the inputs/variables in the job file
+                        rerun_job_file = replace_substring_in_string_list(
+                            rerun_job_file,
+                            "_R_MACE_RERUN_FILE_",
+                            f"{system_auto}_{nnp_index}_{padded_curr_iter}-rerun.in",
+                        )
+                        rerun_job_file = replace_substring_in_string_list(
+                            rerun_job_file,
+                            "_R_RERUN_FILE_",
+                            f' "{system_auto}_{nnp_index}_{padded_curr_iter}-rerun.in"',
+                        )
+                        rerun_job_file = replace_substring_in_string_list(
+                            rerun_job_file,
+                            f"_R_{nnp_program.upper()}_VERSION_",
+                            f"{exploration_json[f'{nnp_program}_model_version']}",
+                        )
+                        rerun_job_file = replace_substring_in_string_list(
+                            rerun_job_file,
+                            "_R_MODEL_FILES_",
+                            str(models_string.replace(" ", '" "')),
+                        )
+                        rerun_job_file = replace_substring_in_string_list(
+                            rerun_job_file,
+                            "_R_LAMMPS_IN_FILE_",
+                            f"{system_auto}_{nnp_index}_{padded_curr_iter}-rerun.in",
+                        )
+                        rerun_job_file = replace_substring_in_string_list(
+                            rerun_job_file,
+                            "_R_LAMMPS_LOG_FILE_",
+                            f"{system_auto}_{nnp_index}_{padded_curr_iter}-rerun.log",
+                        )
+                        rerun_job_file = replace_substring_in_string_list(
+                            rerun_job_file,
+                            "_R_LAMMPS_OUT_FILE_",
+                            f"{system_auto}_{nnp_index}_{padded_curr_iter}-rerun.out",
+                        )
+                        rerun_job_file = replace_substring_in_string_list(
+                            rerun_job_file, "_R_DATA_FILE_", f"{system_lammps_data_fn}"
+                        )
+                        rerun_job_file = replace_substring_in_string_list(
+                            rerun_job_file, plumed_key, plumed_inputs
+                        )
+
+                        string_list_to_textfile(
+                            local_path
+                            / f"job_{system_exploration_type}-{nnp_program}_explore_{arch_type}_{machine}-rerun.sh",
+                            rerun_job_file,
+                            read_only=True,
+                        )
+
                     job_array_params_line += "/"
+
                     job_array_params_file[system_exploration_type].append(
                         job_array_params_line
                     )

--- a/examples/user_files/job_exploration_lammps_slurm/job-array_lammps-mace_explore_gpu_myHPCkeyword1.sh
+++ b/examples/user_files/job_exploration_lammps_slurm/job-array_lammps-mace_explore_gpu_myHPCkeyword1.sh
@@ -50,6 +50,9 @@ EXTRA_FILES=()
 EXTRA_FILES+=("${array_param[4]}")
 if [ -n "${array_param[5]}" ]; then
     EXTRA_FILES+=("${array_param[5]}")
+    MACE_RERUN_FILE="${array_param[5]}"
+    MACE_RERUN_LOG=${MACE_RERUN_FILE/.in/.log}
+    MACE_RERUN_OUT=${MACE_RERUN_FILE/.in/.out}
 fi
 if [ -n "${array_param[6]}" ]; then
     IFS='" "' read -r -a PLUMED_FILES <<< "${array_param[6]}"
@@ -94,7 +97,12 @@ cd "${TEMPWORKDIR}" || { echo "Could not go to ${TEMPWORKDIR}. Aborting..."; exi
 
 echo "# [$(date)] Running LAMMPS..."
 lmp -in "${LAMMPS_IN_FILE}" -log "${LAMMPS_LOG_FILE}" -screen none > "${LAMMPS_OUT_FILE}" 2>&1
-echo "# [$(date)] LAMMPS finished."
+
+if [ $? -eq 0 ]; then
+    echo "# [$(date)] LAMMPS finished."
+else
+    lmp -in "${MACE_RERUN_FILE}" -log "${MACE_RERUN_LOG}" -screen none > "${MACE_RERUN_OUT}" 2>&1
+fi
 
 # Move back data from the temporary work directory and scratch, and clean-up
 if [ -f log.cite ]; then rm log.cite ; fi

--- a/examples/user_files/job_exploration_lammps_slurm/job_lammps-mace_explore_gpu_myHPCkeyword1.sh
+++ b/examples/user_files/job_exploration_lammps_slurm/job_lammps-mace_explore_gpu_myHPCkeyword1.sh
@@ -46,6 +46,10 @@ LAMMPS_LOG_FILE="_R_LAMMPS_LOG_FILE_"
 LAMMPS_OUT_FILE="_R_LAMMPS_OUT_FILE_"
 EXTRA_FILES=("_R_DATA_FILE_" "_R_PLUMED_FILES_" "_R_RERUN_FILE_")
 
+MACE_RERUN_FILE=${EXTRA_FILES[2]}
+MACE_RERUN_LOG=${MACE_RERUN_FILE/.in/.log}
+MACE_RERUN_OUT=${MACE_RERUN_FILE/.in/.out}
+
 #----------------------------------------------
 # Adapt the following lines to your HPC system
 #----------------------------------------------
@@ -82,7 +86,13 @@ cd "${TEMPWORKDIR}" || { echo "Could not go to ${TEMPWORKDIR}. Aborting..."; exi
 
 echo "# [$(date)] Running LAMMPS..."
 lmp -in "${LAMMPS_IN_FILE}" -log "${LAMMPS_LOG_FILE}" -screen none > "${LAMMPS_OUT_FILE}" 2>&1
-echo "# [$(date)] LAMMPS finished."
+
+if [ $? -eq 0 ]; then
+    echo "# [$(date)] LAMMPS finished."
+else
+    lmp -in "${MACE_RERUN_FILE}" -log "${MACE_RERUN_LOG}" -screen none > "${MACE_RERUN_OUT}" 2>&1
+fi
+
 
 # Move back data from the temporary work directory and scratch, and clean-up
 if [ -f log.cite ]; then rm log.cite ; fi


### PR DESCRIPTION
### What does this PR do?

*(Briefly describe the main purpose of this PR in one or two sentences. What problem does it solve or what feature does it add?)*

Add the option to manually run rerun. This is useful for systems that are known to break LAMMPS at some point during the simulation, but rerun on the successful part is still wanted.

This PR adds the preprocessor flag `_R_MACE_RERUN_FILE_`, which can be used in the exploration job file. It also adds it as the last column in the `lst` file, so it can be used in the job-array file. A job file specific for rerun is created in each simulation folder.

### How to test this?

*(Provide clear, step-by-step instructions on how the reviewer can manually test your changes.)*

1. Run `exploration prepare`.
2. Manually submit rerun jobs.

### Next steps?

- What would be the best way to automatically launch rerun calculations? `--rerun` flag on `exploration launch` would be the best, but not possible yet.

---

### Related Issues/Tickets

*(Link to any relevant issues.)*

-- 