### PR TITLE
FIX: version handling and bad mngt in training

### DIFF
--- a/arcann_training/exploration/deviate.py
+++ b/arcann_training/exploration/deviate.py
@@ -816,7 +816,7 @@ def main(
         ) - (skipped_traj_user + skipped_traj_stats)
         if exploitable_traj == 0:
             arcann_logger.critical(
-                "All trajectories were skipped (either by you or discarded by ArcaNN)."
+                f"All trajectories for {system_auto} were skipped (either by you or discarded by ArcaNN)."
             )
             arcann_logger.critical(
                 "You should either change the 'ignore_first_x_ps' value to a lower value to ensure some structure for this exploration."
@@ -824,8 +824,8 @@ def main(
             arcann_logger.critical(
                 "For the next run (or if you redo one), you should reduce 'timestep_ps' and 'print_interval_mult'."
             )
-            arcann_logger.critical("Aborting...")
-            return 1
+            # arcann_logger.critical("Aborting...")
+            # return 1 ##on my opinion, we should not abort if a system doesnt give any points
         else:
             if (
                 exploitable_traj

--- a/arcann_training/training/check.py
+++ b/arcann_training/training/check.py
@@ -228,6 +228,9 @@ def main(
     # Update the boolean in the training JSON
     if completed_count == main_json["nnp_count"]:
         training_json["is_checked"] = True
+    if nnp_program == "mace":  # because we don't need them for mace
+        training_json["is_freeze_launched"] = True
+        training_json["is_frozen"] = True
 
     # If not empty
     if training_times and step_sizes:
@@ -240,6 +243,11 @@ def main(
         training_json["stdeviation_s_per_step"] = np.std(training_times) / np.average(
             step_sizes
         )
+    elif nnp_program == "mace":
+        training_json["mean_s_per_step"] = 0.0
+        training_json["median_s_per_step"] = 0.0
+        training_json["stdeviation_s_per_step"] = 0.0
+
     else:
         training_json["mean_s_per_step"] = -1
         training_json["median_s_per_step"] = -1

--- a/arcann_training/training/check_compress.py
+++ b/arcann_training/training/check_compress.py
@@ -107,6 +107,12 @@ def main(
 
     arcann_logger.debug(f"completed_count: {completed_count}")
 
+    if completed_count == main_json["nnp_count"] or (
+        nnp_program == "mace"
+        and completed_count == main_json["nnp_count"] * len(needed_mace_styles)
+    ):
+        training_json["is_compressed"] = True
+
     # Dump the JSON files (training)
     write_json_file(
         training_json,
@@ -116,10 +122,7 @@ def main(
 
     # End
     arcann_logger.info("-" * 88)
-    if completed_count == main_json["nnp_count"] or (
-        nnp_program == "mace"
-        and completed_count == main_json["nnp_count"] * len(needed_mace_styles)
-    ):
+    if training_json["is_compressed"]:
         arcann_logger.info(
             f"Step: {current_step.capitalize()} - Phase: {current_phase.capitalize()} is a success!"
         )

--- a/arcann_training/training/check_compress.py
+++ b/arcann_training/training/check_compress.py
@@ -76,7 +76,6 @@ def main(
             del local_path
         del nnp
     elif nnp_program == "mace":
-
         for lmp_input in (training_path / "user_files").glob("*.in"):
             needed_mace_styles.add(
                 LAMMPSInputHandler(
@@ -89,7 +88,7 @@ def main(
             )
 
         style_ext = {
-            LAMMPSPair.SYMMETRIX: ".json",
+            LAMMPSPair.SYMMETRIX: ".model.json",
             LAMMPSPair.MACE: "-lammps.pt",
             LAMMPSPair.MLIAP: "-mliap_lammps.pt",
         }
@@ -103,7 +102,7 @@ def main(
                     completed_count += 1
                 else:
                     arcann_logger.critical(
-                        f"DP Compress - '{nnp}-{str(style)}' not finished/failed."
+                        f"MACE Compress - '{nnp}-{str(style)}' not finished/failed."
                     )
 
     arcann_logger.debug(f"completed_count: {completed_count}")

--- a/arcann_training/training/launch.py
+++ b/arcann_training/training/launch.py
@@ -139,15 +139,17 @@ def main(
                         f"./job_{nnp_program}_train_{machine_spec['arch_type']}_{machine}.sh",
                     ]
                 )
-                arcann_logger.info(f"DP Train - '{nnp}' launched.")
+                arcann_logger.info(f"{nnp_program} Train - '{nnp}' launched.")
                 completed_count += 1
             except FileNotFoundError:
                 arcann_logger.critical(
-                    f"DP Train - '{nnp}' NOT launched - '{machine_launch_command}' not found."
+                    f"{nnp_program} Train - '{nnp}' NOT launched - '{machine_launch_command}' not found."
                 )
             change_directory(local_path.parent)
         else:
-            arcann_logger.critical(f"DP Train - '{nnp}' NOT launched - No job file.")
+            arcann_logger.critical(
+                f"{nnp_program} Train - '{nnp}' NOT launched - No job file."
+            )
         del local_path
     del nnp
 
@@ -155,11 +157,6 @@ def main(
     # Update the boolean in the training JSON
     if completed_count == main_json["nnp_count"]:
         training_json["is_launched"] = True
-    if nnp_program == "mace":  # because we don't need them for mace
-        training_json["is_freeze_launched"] = True
-        training_json["is_frozen"] = True
-        training_json["is_compress_launched"] = True
-        training_json["is_compressed"] = True
 
     # Dump the JSON (training JSON)
     write_json_file(

--- a/arcann_training/training/prepare.py
+++ b/arcann_training/training/prepare.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 # Non-standard library imports
 import numpy as np
+from packaging import version
 
 # Local imports
 from arcann_training.common.check import validate_step_folder
@@ -66,6 +67,7 @@ def main(
     # Get the current path and set the training path as the parent of the current path
     current_path = Path().resolve()
     training_path = current_path.parent
+    user_files_path = training_path / "user_files"
 
     # Log the step and phase of the program
     arcann_logger.info(
@@ -192,58 +194,45 @@ def main(
         labeling_json = {}
 
     if "deepmd_model_version" not in user_input_json and nnp_program == "deepmd":
-        dptrain_list = []
-        for file in (current_path.parent / "user_files").iterdir():
-            if file.suffix != ".json":
-                continue
-            if "dptrain" not in file.stem:
-                continue
-            dptrain_list.append(file)
-        arcann_logger.debug(f"dptrain_list: {dptrain_list}")
-        del file
+        found_versions = [
+            f.stem.split("_")[-1] for f in user_files_path.glob("dptrain_*.json")
+        ]
+        arcann_logger.debug(f"Found dptrain versions: {found_versions}")
 
-        if not dptrain_list:
+        if not found_versions:
             arcann_logger.error(
-                f"No dptrain_DEEPMDVERSION.json files found in {(current_path.parent / 'user_files')}"
+                f"No dptrain_DEEPMDVERSION.json files found in {user_files_path}"
             )
             arcann_logger.error("Aborting...")
             return 1
 
-        dptrain_max_version = 0
-        for dptrain in dptrain_list:
-            dptrain_max_version = max(
-                dptrain_max_version, float(dptrain.stem.split("_")[-1])
-            )
-        del dptrain
+        dp_max_version = max(found_versions, key=version.parse)
+        arcann_logger.debug(f"dptrain_max_version: {dp_max_version}")
 
-        arcann_logger.debug(f"dptrain_max_version: {dptrain_max_version}")
-        current_input_json["deepmd_model_version"] = dptrain_max_version
-        del dptrain_list, dptrain_max_version
-
+        current_input_json["deepmd_model_version"] = dp_max_version
         arcann_logger.info(
             f"Using DeePMD version: {current_input_json['deepmd_model_version']}"
         )
 
     elif "mace_model_version" not in user_input_json and nnp_program == "mace":
-        macetrain_list = list(
-            (current_path.parent / "user_files").glob("*.yml")
-        ) + list((current_path.parent / "user_files").glob("*.yaml"))
-        arcann_logger.debug(f"macetrain_list: {macetrain_list}")
+        found_versions = [
+            f.stem.split("_")[-1]
+            for f in user_files_path.glob("mace_*.yml")
+            + user_files_path.glob("mace_*.yaml")
+        ]
+        arcann_logger.debug(f"Found mace versions: {found_versions}")
 
-        if not macetrain_list:
+        if not found_versions:
             arcann_logger.error(
-                f"No macetrain_MACEVERSION.yaml files found in {(current_path.parent / 'user_files')}"
+                f"No mace_MACEVERSION.yaml or mace_MACEVERSION.yml files found in {user_files_path}"
             )
             arcann_logger.error("Aborting...")
             return 1
 
-        mace_max_version = "0"
-        for mace in macetrain_list:
-            mace_max_version = max(mace_max_version, mace.stem.split("_")[-1])
-
+        mace_max_version = max(found_versions, key=version.parse)
         arcann_logger.debug(f"mace_max_version: {mace_max_version}")
-        current_input_json["mace_model_version"] = mace_max_version
 
+        current_input_json["mace_model_version"] = mace_max_version
         arcann_logger.info(
             f"Using MACE version: {current_input_json['mace_model_version']}"
         )
@@ -259,10 +248,8 @@ def main(
 
     # Check if the job file exists
     job_file_name = f"job_{nnp_program}_train_{machine_spec['arch_type']}_{machine}.sh"
-    if (current_path.parent / "user_files" / job_file_name).is_file():
-        master_job_file = textfile_to_string_list(
-            current_path.parent / "user_files" / job_file_name
-        )
+    if (user_files_path / job_file_name).is_file():
+        master_job_file = textfile_to_string_list(user_files_path / job_file_name)
     else:
         arcann_logger.error(
             f"No JOB file provided for '{current_step.capitalize()} / {current_phase.capitalize()}' for this machine."
@@ -284,9 +271,7 @@ def main(
 
         # Check if the default input json file exists
         dp_train_input_path = (
-            training_path
-            / "user_files"
-            / f"dptrain_{training_json['deepmd_model_version']}.json"
+            user_files_path / f"dptrain_{training_json['deepmd_model_version']}.json"
         ).resolve()
 
         nnp_input = load_json_file(dp_train_input_path)
@@ -312,16 +297,12 @@ def main(
         validate_mace_config(training_json)
 
         mace_input_path = (
-            training_path
-            / "user_files"
-            / f"mace_{training_json['mace_model_version']}.yml"
+            user_files_path / f"mace_{training_json['mace_model_version']}.yml"
         ).resolve()
 
         if not mace_input_path.exists():
             mace_input_path = (
-                training_path
-                / "user_files"
-                / f"mace_{training_json['mace_model_version']}.yaml"
+                user_files_path / f"mace_{training_json['mace_model_version']}.yaml"
             ).resolve()
 
         nnp_input = load_yaml_file(mace_input_path)
@@ -361,7 +342,7 @@ def main(
 
         if "foundation_model" in nnp_input:
             fondation_path = (
-                training_path / "user_files" / f"{nnp_input['foundation_model']}"
+                user_files_path / f"{nnp_input['foundation_model']}"
             ).resolve()
             if not fondation_path.is_file():
                 arcann_logger.error(
@@ -589,7 +570,7 @@ def main(
         dataset.prepare_for_mace_train(data_path=localdata_path)
         if nnp_input.get("foundation_model"):
             foundation_model_path = (
-                training_path / "user_files" / f"{nnp_input['foundation_model']}"
+                user_files_path / f"{nnp_input['foundation_model']}"
             ).resolve()
             shutil.copy(
                 foundation_model_path, current_path / foundation_model_path.name

--- a/arcann_training/training/utils.py
+++ b/arcann_training/training/utils.py
@@ -333,10 +333,10 @@ def validate_deepmd_config(training_config) -> None:
         If the configuration is not valid with respect to machine/arch_name/arch and DeePMD.
     """
     # Check DeePMD version
-    if (
-        float(training_config["deepmd_model_version"]) < 2.0
-        or float(training_config["deepmd_model_version"]) > 3.0
-    ):
+    current = version.parse(training_config["deepmd_model_version"])
+    min_v = version.parse("2.0")
+    max_v = version.parse("3.0")
+    if current < min_v or current >= max_v:
         error_msg = f"Only 2.x and 3.0 versions of deepmd are suppported: '{training_config['deepmd_model_version']}'."
         raise ValueError(error_msg)
 

--- a/arcann_training/unittests/test_utils_training.py
+++ b/arcann_training/unittests/test_utils_training.py
@@ -37,12 +37,12 @@ import numpy as np
 
 # Local imports
 from arcann_training.training.utils import (
-    calculate_decay_steps,
     calculate_decay_rate,
+    calculate_decay_steps,
     calculate_learning_rate,
     check_initial_datasets,
-    validate_deepmd_config,
     generate_training_json,
+    validate_deepmd_config,
 )
 
 
@@ -77,24 +77,20 @@ class TestCalculateDecaySteps(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             calculate_decay_steps(0)
         error_msg = str(cm.exception)
-        expected_error_msg = (
-            f"The argument 'num_structures' must be a positive integer."
-        )
+        expected_error_msg = "The argument 'num_structures' must be a positive integer."
         self.assertEqual(error_msg, expected_error_msg)
 
         with self.assertRaises(ValueError) as cm:
             calculate_decay_steps(-100)
         error_msg = str(cm.exception)
-        expected_error_msg = (
-            f"The argument 'num_structures' must be a positive integer."
-        )
+        expected_error_msg = "The argument 'num_structures' must be a positive integer."
         self.assertEqual(error_msg, expected_error_msg)
 
         with self.assertRaises(ValueError) as cm:
             calculate_decay_steps(100, min_decay_steps=-500)
         error_msg = str(cm.exception)
         expected_error_msg = (
-            f"The argument 'min_decay_steps' must be a positive integer."
+            "The argument 'min_decay_steps' must be a positive integer."
         )
         self.assertEqual(error_msg, expected_error_msg)
 
@@ -139,22 +135,22 @@ class TestCalculateDecayRate(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             calculate_decay_rate(100, -0.01, 0.001, 5000)
         error_msg = str(cm.exception)
-        expected_error_msg = f"The argument 'start_lr' must be a positive number."
+        expected_error_msg = "The argument 'start_lr' must be a positive number."
         self.assertEqual(error_msg, expected_error_msg)
         with self.assertRaises(ValueError) as cm:
             calculate_decay_rate(100, 0, 0.001, 5000)
         error_msg = str(cm.exception)
-        expected_error_msg = f"The argument 'start_lr' must be a positive number."
+        expected_error_msg = "The argument 'start_lr' must be a positive number."
         self.assertEqual(error_msg, expected_error_msg)
         with self.assertRaises(ValueError) as cm:
             calculate_decay_rate(100, 0.01, 0.001, 0)
         error_msg = str(cm.exception)
-        expected_error_msg = f"The argument 'decay_steps' must be a positive integer."
+        expected_error_msg = "The argument 'decay_steps' must be a positive integer."
         self.assertEqual(error_msg, expected_error_msg)
         with self.assertRaises(ValueError) as cm:
             calculate_decay_rate(100, 0.01, 0.001, 0.0003)
         error_msg = str(cm.exception)
-        expected_error_msg = f"The argument 'decay_steps' must be a positive integer."
+        expected_error_msg = "The argument 'decay_steps' must be a positive integer."
         self.assertEqual(error_msg, expected_error_msg)
 
     def test_calculate_decay_rate_output_type(self):
@@ -202,27 +198,27 @@ class TestCalculateLearningRate(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             calculate_learning_rate(-100, 0.01, 0.1, 5000)
         error_msg = str(cm.exception)
-        expected_error_msg = f"All arguments must be positive."
+        expected_error_msg = "All arguments must be positive."
         self.assertEqual(error_msg, expected_error_msg)
         with self.assertRaises(ValueError) as cm:
             calculate_learning_rate(100, -0.01, 0.1, 5000)
         error_msg = str(cm.exception)
-        expected_error_msg = f"All arguments must be positive."
+        expected_error_msg = "All arguments must be positive."
         self.assertEqual(error_msg, expected_error_msg)
         with self.assertRaises(ValueError) as cm:
             calculate_learning_rate(100, 0.01, -0.1, 5000)
         error_msg = str(cm.exception)
-        expected_error_msg = f"All arguments must be positive."
+        expected_error_msg = "All arguments must be positive."
         self.assertEqual(error_msg, expected_error_msg)
         with self.assertRaises(ValueError) as cm:
             calculate_learning_rate(1000, 0.01, 0.1, -5000)
         error_msg = str(cm.exception)
-        expected_error_msg = f"All arguments must be positive."
+        expected_error_msg = "All arguments must be positive."
         self.assertEqual(error_msg, expected_error_msg)
         with self.assertRaises(ValueError) as cm:
             calculate_learning_rate(100, 0.01, 0.1, 3213332.2)
         error_msg = str(cm.exception)
-        expected_error_msg = f"The argument 'decay_steps' must be a positive integer."
+        expected_error_msg = "The argument 'decay_steps' must be a positive integer."
         self.assertEqual(error_msg, expected_error_msg)
 
     def test_calculate_learning_rate_output_type(self):
@@ -277,12 +273,12 @@ class TestCheckInitialDatasets(unittest.TestCase):
             Path(self.temp_dir.name) / "data" / "dataset1" / "set.000" / "box.npy",
             np.zeros(50),
         )
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ValueError):
             check_initial_datasets(Path(self.temp_dir.name))
 
     def test_check_initial_datasets_missing_json(self):
         (Path(self.temp_dir.name) / "control" / "initial_datasets.json").unlink()
-        with self.assertRaises(FileNotFoundError) as cm:
+        with self.assertRaises(FileNotFoundError):
             check_initial_datasets(Path(self.temp_dir.name))
 
     def test_check_initial_datasets_missing_dataset(self):
@@ -291,7 +287,7 @@ class TestCheckInitialDatasets(unittest.TestCase):
         ).unlink()
         (Path(self.temp_dir.name) / "data" / "dataset2" / "set.000").rmdir()
         (Path(self.temp_dir.name) / "data" / "dataset2").rmdir()
-        with self.assertRaises(FileNotFoundError) as cm:
+        with self.assertRaises(FileNotFoundError):
             check_initial_datasets(Path(self.temp_dir.name))
 
 
@@ -312,7 +308,7 @@ class TestDeepMDConfigValidation(unittest.TestCase):
         Tests if the function correctly validates a valid configuration.
         """
         config = {
-            "deepmd_model_version": 2.1,
+            "deepmd_model_version": "2.1",
             "arch_name": "a100",
         }
         self.assertIsNone(validate_deepmd_config(config))
@@ -322,7 +318,7 @@ class TestDeepMDConfigValidation(unittest.TestCase):
         Tests if the function raises a ValueError for an invalid model version.
         """
         config = {
-            "deepmd_model_version": 1.5,
+            "deepmd_model_version": "1.5",
         }
         with self.assertRaises(ValueError):
             validate_deepmd_config(config)


### PR DESCRIPTION
Fix several bugs:
- Versions are now properly managed as `str` and not float with the appropriate library
- `mean_s_per_step` etc.. that are not included in the mace training are handled without error
- For mace, `frozen` is set after the `check` step only, `compress` only if launched
- A line has been deleted which never wrote `is_compresse: true` for the training step in the control file

**Note**
On my opinion, we should not have to abort when all the trajectories of a system are not usable, because we may want to use the systems in the next iterations where performance are better. Do you agree with this modification?