### PR TITLE
FIX: solve some problems with MACE

### DIFF
--- a/arcann_training/common/lammps.py
+++ b/arcann_training/common/lammps.py
@@ -32,7 +32,9 @@ from typing import Literal
 try:
     from enum import StrEnum
 except ImportError:
-    from strenum import StrEnum  # type: ignore
+    from strenum import LowercaseStrEnum  # type: ignore
+
+    StrEnum = LowercaseStrEnum
 
 # Third-party modules
 import numpy as np

--- a/arcann_training/common/lammps.py
+++ b/arcann_training/common/lammps.py
@@ -257,6 +257,7 @@ class LAMMPSInputHandler:
         "dump traj_frc all custom _R_PRINT_FREQ_ _RI_NAME__mace_forces_model1.lammpstrj id type x y z fx fy fz",
         "dump_modify traj_xyz sort id",
         "dump_modify traj_frc sort id",
+        "",
     )
 
     def __init__(self, lmp_input: str | Path, elements: list[str]):

--- a/arcann_training/training/prepare.py
+++ b/arcann_training/training/prepare.py
@@ -217,8 +217,8 @@ def main(
     elif "mace_model_version" not in user_input_json and nnp_program == "mace":
         found_versions = [
             f.stem.split("_")[-1]
-            for f in user_files_path.glob("mace_*.yml")
-            + user_files_path.glob("mace_*.yaml")
+            for f in list(user_files_path.glob("mace_*.yml"))
+            + list(user_files_path.glob("mace_*.yaml"))
         ]
         arcann_logger.debug(f"Found mace versions: {found_versions}")
 


### PR DESCRIPTION
This PR fixes an error in python 3.10 with the case of the `LAMMPSPair` enum, an error with the trying to sum generators, and wrong print of dump configurations on the LAMMPS input after parsing.