### PR TITLE
fix(dataset): correct energy read from deepmd

### DIFF
--- a/arcann_training/common/dataset.py
+++ b/arcann_training/common/dataset.py
@@ -229,7 +229,7 @@ class Set000Ensemble(DataEnsemble):
                 cell=self.box[i].reshape(3, 3),
                 pbc=self.is_periodic,
             )
-            frame.info["REF_energy"] = np.array([float(self.energy[i])])
+            frame.info["REF_energy"] = float(self.energy[i])
             frame.arrays["REF_forces"] = self.force[i].reshape(-1, 3)
             if self.virial is not None:
                 frame.info["REF_virials"] = self.virial[i].reshape(3, 3)

--- a/arcann_training/common/dataset.py
+++ b/arcann_training/common/dataset.py
@@ -174,7 +174,7 @@ class Set000Ensemble(DataEnsemble):
         self.type = np.loadtxt(self.path / "type.raw", dtype=int)
         self.box = np.load(self.path / "set.000" / "box.npy")
         self.coord = np.load(self.path / "set.000" / "coord.npy")
-        self.energy = np.load(self.path / "set.000" / "energy.npy")
+        self.energy = np.load(self.path / "set.000" / "energy.npy").flatten()
         self.force = np.load(self.path / "set.000" / "force.npy")
         self.virial = (
             np.load(self.path / "set.000" / "virial.npy")


### PR DESCRIPTION
This PR fixes an error that was raised when trying to set the energy of a frame in dataset conversion (to extxyz) as a numpy array. Also guarantees that the energy array is flat.