### PR TITLE
FIX: correct filename in check_compress for libtorch LAMMPS pair_style

### DIFF
--- a/arcann_training/training/check_compress.py
+++ b/arcann_training/training/check_compress.py
@@ -89,7 +89,7 @@ def main(
 
         style_ext = {
             LAMMPSPair.SYMMETRIX: ".model.json",
-            LAMMPSPair.MACE: "-lammps.pt",
+            LAMMPSPair.MACE: ".model-lammps.pt",
             LAMMPSPair.MLIAP: "-mliap_lammps.pt",
         }
 

--- a/arcann_training/training/increment.py
+++ b/arcann_training/training/increment.py
@@ -126,7 +126,7 @@ def main(
             if training_json["is_compressed"]:
                 for conv_mod in [
                     f
-                    for ext in ("json", "model", "-lammps.pt", "-mliap_lammps.pt")
+                    for ext in ("json", "model", "model-lammps.pt", "-mliap_lammps.pt")
                     for f in nnp_path.glob(f"model*.{ext}")
                 ]:
                     subprocess.run(  # noqa: S603


### PR DESCRIPTION
This PR corrects the filename to be checked on `check_compress` when using the libtorch LAMMPS MACE pair_style.