### PR TITLE
FIXES: solves transition phase and compress/check_compress bugs

### DIFF
--- a/arcann_training/initialization/transition.py
+++ b/arcann_training/initialization/transition.py
@@ -214,9 +214,10 @@ def main(
         extra_dataset=True,
         init_dataset=True,
     )
+
     dataset.convert_dataset(
         to_extxyz=(main_json["data_format"] == "extxyz"),
-        to_set000=(main_json["data_format"] == "set000"),
+        to_set000=(main_json["data_format"] == "set.000"),
     )
     dataset.update_control_file()
 

--- a/arcann_training/training/check_compress.py
+++ b/arcann_training/training/check_compress.py
@@ -87,6 +87,14 @@ def main(
                 ).lmp_pair
             )
 
+        if not needed_mace_styles:
+            arcann_logger.error(
+                "No LAMMPS '.in' input template found in 'user_files/' - "
+                "cannot determine which pair_style(s) were compressed."
+            )
+            arcann_logger.error("Aborting...")
+            return 1
+
         style_ext = {
             LAMMPSPair.SYMMETRIX: ".model.json",
             LAMMPSPair.MACE: "-lammps.pt",

--- a/arcann_training/training/compress.py
+++ b/arcann_training/training/compress.py
@@ -296,6 +296,14 @@ def main(
                 ).lmp_pair
             )
 
+        if not needed_mace_styles:
+            arcann_logger.error(
+                "No LAMMPS '.in' input template found in 'user_files/' - "
+                "cannot determine which pair_style(s) to compress for."
+            )
+            arcann_logger.error("Aborting...")
+            return 1
+
         for nnp in range(1, main_json["nnp_count"] + 1):
             for style in needed_mace_styles:
                 local_path = current_path / f"{nnp}" / "MACE_models"


### PR DESCRIPTION
This PR fixes an issue when using init/transition to convert extxyz -> set.000, it finished without converting. And now raises an error when doing compress with MACE when no LAMMPS input is found to identify the pair_style.